### PR TITLE
stop seamonkey patches from fuzzing

### DIFF
--- a/seamonkey/1000_fix-preferences-gentoo.patch
+++ b/seamonkey/1000_fix-preferences-gentoo.patch
@@ -1,11 +1,8 @@
---- seamonkey-2.53.6b1/comm/suite/installer/package-manifest.in
-+++ seamonkey-2.53.6b1/comm/suite/installer/package-manifest.in
-@@ -603,16 +603,17 @@
- @RESPATH@/chrome/icons/default/places.ico
- @RESPATH@/chrome/icons/default/script-file.ico
- @RESPATH@/chrome/icons/default/xml-file.ico
- @RESPATH@/chrome/icons/default/xul-file.ico
- #endif
+diff --git a/comm/suite/installer/package-manifest.in b/comm/suite/installer/package-manifest.in
+index 0b8f4d8..7e815f4 100644
+--- a/comm/suite/installer/package-manifest.in
++++ b/comm/suite/installer/package-manifest.in
+@@ -604,6 +604,7 @@
  
  ; [Default Preferences]
  ; All the browser/general pref files must be part of base to prevent migration bugs
@@ -13,8 +10,3 @@
  @RESPATH@/@PREF_DIR@/suite-prefs.js
  @RESPATH@/@PREF_DIR@/composer.js
  @RESPATH@/greprefs.js
- @RESPATH@/defaults/autoconfig/prefcalls.js
- @RESPATH@/defaults/permissions
- @RESPATH@/defaults/blocklists
- @RESPATH@/defaults/pinning
- ; Warning: changing the path to channel-prefs.js can cause bugs. (Bug 756325)

--- a/seamonkey/1007_re-add_system_sqlite.patch
+++ b/seamonkey/1007_re-add_system_sqlite.patch
@@ -1,7 +1,8 @@
-diff -ru seamonkey-2.53.10.2.orig/browser/installer/package-manifest.in seamonkey-2.53.10.2/browser/installer/package-manifest.in
---- seamonkey-2.53.10.2.orig/browser/installer/package-manifest.in	2021-10-26 18:49:53.000000000 +0200
-+++ seamonkey-2.53.10.2/browser/installer/package-manifest.in	2022-01-24 12:49:37.256167159 +0100
-@@ -129,9 +129,11 @@
+diff --git a/browser/installer/package-manifest.in b/browser/installer/package-manifest.in
+index ec783ee..7bdfff0 100644
+--- a/browser/installer/package-manifest.in
++++ b/browser/installer/package-manifest.in
+@@ -130,9 +130,11 @@
  @RESPATH@/update-settings.ini
  #endif
  @RESPATH@/platform.ini
@@ -13,10 +14,11 @@ diff -ru seamonkey-2.53.10.2.orig/browser/installer/package-manifest.in seamonke
  @BINPATH@/@DLL_PREFIX@lgpllibs@DLL_SUFFIX@
  #ifdef MOZ_FFVPX
  @BINPATH@/@DLL_PREFIX@mozavutil@DLL_SUFFIX@
-diff -ru seamonkey-2.53.10.2.orig/build/moz.configure/old.configure seamonkey-2.53.10.2/build/moz.configure/old.configure
---- seamonkey-2.53.10.2.orig/build/moz.configure/old.configure	2021-10-26 18:49:53.000000000 +0200
-+++ seamonkey-2.53.10.2/build/moz.configure/old.configure	2022-01-24 12:50:39.242805683 +0100
-@@ -215,6 +215,7 @@
+diff --git a/build/moz.configure/old.configure b/build/moz.configure/old.configure
+index 006e978..c1dd8c9 100644
+--- a/build/moz.configure/old.configure
++++ b/build/moz.configure/old.configure
+@@ -240,6 +240,7 @@ def old_configure_options(*options):
      '--enable-system-cairo',
      '--enable-system-extension-dirs',
      '--enable-system-pixman',
@@ -24,9 +26,10 @@ diff -ru seamonkey-2.53.10.2.orig/build/moz.configure/old.configure seamonkey-2.
      '--enable-universalchardet',
      '--enable-updater',
      '--enable-xul',
-diff -ru seamonkey-2.53.10.2.orig/config/external/sqlite/moz.build seamonkey-2.53.10.2/config/external/sqlite/moz.build
---- seamonkey-2.53.10.2.orig/config/external/sqlite/moz.build	2020-10-20 21:17:57.000000000 +0200
-+++ seamonkey-2.53.10.2/config/external/sqlite/moz.build	2022-01-24 12:52:37.902856568 +0100
+diff --git a/config/external/sqlite/moz.build b/config/external/sqlite/moz.build
+index dc575ec..1e4c6b0 100644
+--- a/config/external/sqlite/moz.build
++++ b/config/external/sqlite/moz.build
 @@ -4,15 +4,19 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -56,18 +59,19 @@ diff -ru seamonkey-2.53.10.2.orig/config/external/sqlite/moz.build seamonkey-2.5
  
 -    SYMBOLS_FILE = '/third_party/sqlite3/src/sqlite.symbols'
 +        SYMBOLS_FILE = '/third_party/sqlite3/src/sqlite.symbols'
-diff -ru seamonkey-2.53.10.2.orig/old-configure.in seamonkey-2.53.10.2/old-configure.in
---- seamonkey-2.53.10.2.orig/old-configure.in	2021-10-26 18:49:54.000000000 +0200
-+++ seamonkey-2.53.10.2/old-configure.in	2022-01-24 12:55:05.436136470 +0100
-@@ -65,6 +65,7 @@
- GCONF_VERSION=1.2.1
- STARTUP_NOTIFICATION_VERSION=0.8
+diff --git a/old-configure.in b/old-configure.in
+index 715c878..9594353 100644
+--- a/old-configure.in
++++ b/old-configure.in
+@@ -61,6 +61,7 @@ GTK3_VERSION=3.4.0
+ GDK_VERSION_MAX_ALLOWED=GDK_VERSION_3_4
+ W32API_VERSION=3.14
  DBUS_VERSION=0.60
 +SQLITE_VERSION=3.36.0
  
  dnl Set various checks
  dnl ========================================================
-@@ -3072,11 +3073,35 @@
+@@ -2153,11 +2154,35 @@ else
      fi
  fi
  
@@ -108,10 +112,42 @@ diff -ru seamonkey-2.53.10.2.orig/old-configure.in seamonkey-2.53.10.2/old-confi
  
  dnl ========================================================
  dnl = Disable zipwriter
-diff -ru seamonkey-2.53.10.2.orig/storage/moz.build seamonkey-2.53.10.2/storage/moz.build
---- seamonkey-2.53.10.2.orig/storage/moz.build	2021-10-26 18:49:54.000000000 +0200
-+++ seamonkey-2.53.10.2/storage/moz.build	2022-01-24 12:56:04.669657805 +0100
-@@ -97,6 +97,12 @@
+diff --git a/storage/SQLiteMutex.h b/storage/SQLiteMutex.h
+index 055fe8a..e154333 100644
+--- a/storage/SQLiteMutex.h
++++ b/storage/SQLiteMutex.h
+@@ -62,7 +62,7 @@ public:
+    */
+   void lock() {
+     MOZ_ASSERT(mMutex, "No mutex associated with this wrapper!");
+-#if defined(DEBUG)
++#if defined(DEBUG) && !defined(MOZ_SYSTEM_SQLITE)
+     // While SQLite Mutexes may be recursive, in our own code we do not want to
+     // treat them as such.
+     CheckAcquire();
+@@ -70,7 +70,7 @@ public:
+ 
+     ::sqlite3_mutex_enter(mMutex);
+ 
+-#if defined(DEBUG)
++#if defined(DEBUG) && !defined(MOZ_SYSTEM_SQLITE)
+     Acquire();  // Call is protected by us holding the mutex.
+ #endif
+   }
+@@ -80,7 +80,7 @@ public:
+    */
+   void unlock() {
+     MOZ_ASSERT(mMutex, "No mutex associated with this wrapper!");
+-#if defined(DEBUG)
++#if defined(DEBUG) && !defined(MOZ_SYSTEM_SQLITE)
+     // While SQLite Mutexes may be recursive, in our own code we do not want to
+     // treat them as such.
+     Release();  // Call is protected by us holding the mutex.
+diff --git a/storage/moz.build b/storage/moz.build
+index 041c5a6..3d28134 100644
+--- a/storage/moz.build
++++ b/storage/moz.build
+@@ -97,6 +97,12 @@ if CONFIG['MOZ_THUNDERBIRD'] or CONFIG['MOZ_SUITE']:
  # will need to change it here as well.
  DEFINES['SQLITE_MAX_LIKE_PATTERN_LENGTH'] = 50000
  
@@ -124,10 +160,11 @@ diff -ru seamonkey-2.53.10.2.orig/storage/moz.build seamonkey-2.53.10.2/storage/
  LOCAL_INCLUDES += [
      '/dom/base',
      '/third_party/sqlite3/src',
-diff -ru seamonkey-2.53.10.2.orig/storage/mozStorageConnection.cpp seamonkey-2.53.10.2/storage/mozStorageConnection.cpp
---- seamonkey-2.53.10.2.orig/storage/mozStorageConnection.cpp	2021-10-26 18:49:54.000000000 +0200
-+++ seamonkey-2.53.10.2/storage/mozStorageConnection.cpp	2022-01-24 12:56:59.977012018 +0100
-@@ -844,6 +844,10 @@
+diff --git a/storage/mozStorageConnection.cpp b/storage/mozStorageConnection.cpp
+index 56c9df2..56c7f77 100644
+--- a/storage/mozStorageConnection.cpp
++++ b/storage/mozStorageConnection.cpp
+@@ -844,6 +844,10 @@ Connection::initializeInternal()
      return convertResultCode(srv);
    }
  
@@ -138,9 +175,10 @@ diff -ru seamonkey-2.53.10.2.orig/storage/mozStorageConnection.cpp seamonkey-2.5
    // Register our built-in SQL functions.
    srv = registerFunctions(mDBConn);
    if (srv != SQLITE_OK) {
-diff -ru seamonkey-2.53.10.2.orig/storage/mozStorageService.cpp seamonkey-2.53.10.2/storage/mozStorageService.cpp
---- seamonkey-2.53.10.2.orig/storage/mozStorageService.cpp	2021-10-26 18:49:54.000000000 +0200
-+++ seamonkey-2.53.10.2/storage/mozStorageService.cpp	2022-01-24 12:59:07.358434136 +0100
+diff --git a/storage/mozStorageService.cpp b/storage/mozStorageService.cpp
+index df8bfb1..2d7bdff 100644
+--- a/storage/mozStorageService.cpp
++++ b/storage/mozStorageService.cpp
 @@ -32,6 +32,8 @@
  #undef CompareString
  #endif
@@ -150,8 +188,8 @@ diff -ru seamonkey-2.53.10.2.orig/storage/mozStorageService.cpp seamonkey-2.53.1
  ////////////////////////////////////////////////////////////////////////////////
  //// Defines
  
-@@ -196,6 +198,31 @@
-     return gService;
+@@ -195,6 +197,31 @@ Service::getSingleton()
+     return do_AddRef(gService);
    }
  
 +  // Ensure that we are using the same version of SQLite that we compiled with
@@ -182,40 +220,11 @@ diff -ru seamonkey-2.53.10.2.orig/storage/mozStorageService.cpp seamonkey-2.53.1
    // The first reference to the storage service must be obtained on the
    // main thread.
    NS_ENSURE_TRUE(NS_IsMainThread(), nullptr);
-diff -ru seamonkey-2.53.10.2.orig/storage/SQLiteMutex.h seamonkey-2.53.10.2/storage/SQLiteMutex.h
---- seamonkey-2.53.10.2.orig/storage/SQLiteMutex.h	2020-10-20 21:17:58.000000000 +0200
-+++ seamonkey-2.53.10.2/storage/SQLiteMutex.h	2022-01-24 13:01:29.433481704 +0100
-@@ -62,7 +62,7 @@
-    */
-   void lock() {
-     MOZ_ASSERT(mMutex, "No mutex associated with this wrapper!");
--#if defined(DEBUG)
-+#if defined(DEBUG) && !defined(MOZ_SYSTEM_SQLITE)
-     // While SQLite Mutexes may be recursive, in our own code we do not want to
-     // treat them as such.
-     CheckAcquire();
-@@ -70,7 +70,7 @@
- 
-     ::sqlite3_mutex_enter(mMutex);
- 
--#if defined(DEBUG)
-+#if defined(DEBUG) && !defined(MOZ_SYSTEM_SQLITE)
-     Acquire();  // Call is protected by us holding the mutex.
- #endif
-   }
-@@ -80,7 +80,7 @@
-    */
-   void unlock() {
-     MOZ_ASSERT(mMutex, "No mutex associated with this wrapper!");
--#if defined(DEBUG)
-+#if defined(DEBUG) && !defined(MOZ_SYSTEM_SQLITE)
-     // While SQLite Mutexes may be recursive, in our own code we do not want to
-     // treat them as such.
-     Release();  // Call is protected by us holding the mutex.
-diff -ru seamonkey-2.53.10.2.orig/third_party/sqlite3/src/moz.build seamonkey-2.53.10.2/third_party/sqlite3/src/moz.build
---- seamonkey-2.53.10.2.orig/third_party/sqlite3/src/moz.build	2021-10-26 18:49:55.000000000 +0200
-+++ seamonkey-2.53.10.2/third_party/sqlite3/src/moz.build	2022-01-24 13:02:55.933163651 +0100
-@@ -80,6 +80,7 @@
+diff --git a/third_party/sqlite3/src/moz.build b/third_party/sqlite3/src/moz.build
+index 2edb816..37632fb 100644
+--- a/third_party/sqlite3/src/moz.build
++++ b/third_party/sqlite3/src/moz.build
+@@ -80,6 +80,7 @@ DEFINES['SQLITE_OMIT_DECLTYPE'] = True
  # Try to use a MEMORY temp store when possible. That allows for better
  # performance and doesn't suffer from a full separate tmp partition.
  # Exclude 32bit platforms due to address space fragmentation issues.
@@ -223,7 +232,7 @@ diff -ru seamonkey-2.53.10.2.orig/third_party/sqlite3/src/moz.build seamonkey-2.
  if CONFIG['OS_TARGET'] == 'Android':
      # On Android there's no tmp partition, so always use a MEMORY temp store.
      DEFINES['SQLITE_TEMP_STORE'] = 3
-@@ -89,6 +90,7 @@
+@@ -89,6 +90,7 @@ elif CONFIG['HAVE_64BIT_BUILD']:
  
  # Change the default temp files prefix, to easily distinguish files we created
  # vs files created by other Sqlite instances in the system.
@@ -231,10 +240,11 @@ diff -ru seamonkey-2.53.10.2.orig/third_party/sqlite3/src/moz.build seamonkey-2.
  DEFINES['SQLITE_TEMP_FILE_PREFIX'] = '"mz_etilqs_"'
  
  # Enabling sqlite math functions
-diff -ru seamonkey-2.53.10.2.orig/third_party/sqlite3/src/sqlite.symbols seamonkey-2.53.10.2/third_party/sqlite3/src/sqlite.symbols
---- seamonkey-2.53.10.2.orig/third_party/sqlite3/src/sqlite.symbols	2020-10-20 21:17:59.000000000 +0200
-+++ seamonkey-2.53.10.2/third_party/sqlite3/src/sqlite.symbols	2022-01-24 13:03:23.661343928 +0100
-@@ -35,6 +35,7 @@
+diff --git a/third_party/sqlite3/src/sqlite.symbols b/third_party/sqlite3/src/sqlite.symbols
+index 7514114..3a0fbc5 100644
+--- a/third_party/sqlite3/src/sqlite.symbols
++++ b/third_party/sqlite3/src/sqlite.symbols
+@@ -35,6 +35,7 @@ sqlite3_column_text
  sqlite3_column_text16
  sqlite3_column_type
  sqlite3_column_value

--- a/seamonkey/1014_seamonkey-2.53.11-fix_sandbox_on_ppc64.patch
+++ b/seamonkey/1014_seamonkey-2.53.11-fix_sandbox_on_ppc64.patch
@@ -20,7 +20,7 @@ Subject: [PATCH 1/3] ppc64 patchset
  create mode 100644 security/sandbox/chromium/sandbox/linux/system_headers/ppc64_linux_ucontext.h
 
 diff --git a/security/sandbox/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h b/security/sandbox/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
-index a747770c7..e04dd41ae 100644
+index a747770..e04dd41 100644
 --- a/security/sandbox/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
 +++ b/security/sandbox/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
 @@ -50,6 +50,13 @@
@@ -38,7 +38,7 @@ index a747770c7..e04dd41ae 100644
  #error "Unsupported architecture"
  #endif
 diff --git a/security/sandbox/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h b/security/sandbox/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
-index af70f21cd..e50b31425 100644
+index af70f21..5d93dd5 100644
 --- a/security/sandbox/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
 +++ b/security/sandbox/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
 @@ -16,6 +16,9 @@
@@ -51,7 +51,7 @@ index af70f21cd..e50b31425 100644
  #endif
  #endif
  
-@@ -286,6 +289,51 @@ struct regs_struct {
+@@ -286,6 +289,62 @@ struct regs_struct {
  #define SECCOMP_PT_PARM4(_regs) (_regs).regs[3]
  #define SECCOMP_PT_PARM5(_regs) (_regs).regs[4]
  #define SECCOMP_PT_PARM6(_regs) (_regs).regs[5]
@@ -81,6 +81,7 @@ index af70f21cd..e50b31425 100644
 +
 +#define SECCOMP_NR_IDX (offsetof(struct arch_seccomp_data, nr))
 +#define SECCOMP_ARCH_IDX (offsetof(struct arch_seccomp_data, arch))
++#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 +#define SECCOMP_IP_MSB_IDX \
 +  (offsetof(struct arch_seccomp_data, instruction_pointer) + 4)
 +#define SECCOMP_IP_LSB_IDX \
@@ -89,6 +90,16 @@ index af70f21cd..e50b31425 100644
 +  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 4)
 +#define SECCOMP_ARG_LSB_IDX(nr) \
 +  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 0)
++#else
++#define SECCOMP_IP_MSB_IDX \
++  (offsetof(struct arch_seccomp_data, instruction_pointer) + 0)
++#define SECCOMP_IP_LSB_IDX \
++  (offsetof(struct arch_seccomp_data, instruction_pointer) + 4)
++#define SECCOMP_ARG_MSB_IDX(nr) \
++  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 0)
++#define SECCOMP_ARG_LSB_IDX(nr) \
++  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 4)
++#endif
 +
 +#define SECCOMP_PT_RESULT(_regs) (_regs).gpr[3]
 +#define SECCOMP_PT_SYSCALL(_regs) (_regs).gpr[0]
@@ -104,7 +115,7 @@ index af70f21cd..e50b31425 100644
  #error Unsupported target platform
  
 diff --git a/security/sandbox/chromium/sandbox/linux/seccomp-bpf/syscall.cc b/security/sandbox/chromium/sandbox/linux/seccomp-bpf/syscall.cc
-index 4d5593618..3789aa617 100644
+index 4d55936..3789aa6 100644
 --- a/security/sandbox/chromium/sandbox/linux/seccomp-bpf/syscall.cc
 +++ b/security/sandbox/chromium/sandbox/linux/seccomp-bpf/syscall.cc
 @@ -15,7 +15,7 @@ namespace sandbox {
@@ -204,10 +215,10 @@ index 4d5593618..3789aa617 100644
    SECCOMP_RESULT(ctx) = static_cast<greg_t>(ret_val);
  }
 diff --git a/security/sandbox/chromium/sandbox/linux/seccomp-bpf/trap.cc b/security/sandbox/chromium/sandbox/linux/seccomp-bpf/trap.cc
-index 2103251c0..5f75e7b73 100644
+index 003708d..8f9b3af 100644
 --- a/security/sandbox/chromium/sandbox/linux/seccomp-bpf/trap.cc
 +++ b/security/sandbox/chromium/sandbox/linux/seccomp-bpf/trap.cc
-@@ -229,6 +229,20 @@ void Trap::SigSys(int nr, LinuxSigInfo* info, ucontext_t* ctx) {
+@@ -225,6 +225,20 @@ void Trap::SigSys(int nr, LinuxSigInfo* info, ucontext_t* ctx) {
        SetIsInSigHandler();
      }
  
@@ -229,7 +240,7 @@ index 2103251c0..5f75e7b73 100644
      // is what we are showing to TrapFnc callbacks that the system call
      // evaluator registered with the sandbox.
 diff --git a/security/sandbox/chromium/sandbox/linux/services/syscall_wrappers.cc b/security/sandbox/chromium/sandbox/linux/services/syscall_wrappers.cc
-index 9c7727cee..1be92db4a 100644
+index 9c7727c..1be92db 100644
 --- a/security/sandbox/chromium/sandbox/linux/services/syscall_wrappers.cc
 +++ b/security/sandbox/chromium/sandbox/linux/services/syscall_wrappers.cc
 @@ -59,7 +59,7 @@ long sys_clone(unsigned long flags,
@@ -242,7 +253,7 @@ index 9c7727cee..1be92db4a 100644
    return syscall(__NR_clone, flags, child_stack, ptid, tls, ctid);
  #endif
 diff --git a/security/sandbox/chromium/sandbox/linux/system_headers/linux_seccomp.h b/security/sandbox/chromium/sandbox/linux/system_headers/linux_seccomp.h
-index 3deb3d225..d36bd724f 100644
+index 3deb3d2..d36bd72 100644
 --- a/security/sandbox/chromium/sandbox/linux/system_headers/linux_seccomp.h
 +++ b/security/sandbox/chromium/sandbox/linux/system_headers/linux_seccomp.h
 @@ -29,6 +29,9 @@
@@ -269,7 +280,7 @@ index 3deb3d225..d36bd724f 100644
  // For prctl.h
  #ifndef PR_SET_SECCOMP
 diff --git a/security/sandbox/chromium/sandbox/linux/system_headers/linux_signal.h b/security/sandbox/chromium/sandbox/linux/system_headers/linux_signal.h
-index fb9a47b8d..a610f3454 100644
+index fb9a47b..a610f34 100644
 --- a/security/sandbox/chromium/sandbox/linux/system_headers/linux_signal.h
 +++ b/security/sandbox/chromium/sandbox/linux/system_headers/linux_signal.h
 @@ -11,7 +11,7 @@
@@ -282,7 +293,7 @@ index fb9a47b8d..a610f3454 100644
  #define LINUX_SIGHUP 1
  #define LINUX_SIGINT 2
 diff --git a/security/sandbox/chromium/sandbox/linux/system_headers/linux_syscalls.h b/security/sandbox/chromium/sandbox/linux/system_headers/linux_syscalls.h
-index 2b441e47e..0b7456ae8 100644
+index 2b441e4..0b7456a 100644
 --- a/security/sandbox/chromium/sandbox/linux/system_headers/linux_syscalls.h
 +++ b/security/sandbox/chromium/sandbox/linux/system_headers/linux_syscalls.h
 @@ -33,5 +33,9 @@
@@ -296,7 +307,7 @@ index 2b441e47e..0b7456ae8 100644
  #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_SYSCALLS_H_
  
 diff --git a/security/sandbox/chromium/sandbox/linux/system_headers/linux_ucontext.h b/security/sandbox/chromium/sandbox/linux/system_headers/linux_ucontext.h
-index ea4d8a6c1..2f950b525 100644
+index ea4d8a6..2f950b5 100644
 --- a/security/sandbox/chromium/sandbox/linux/system_headers/linux_ucontext.h
 +++ b/security/sandbox/chromium/sandbox/linux/system_headers/linux_ucontext.h
 @@ -17,6 +17,8 @@
@@ -310,7 +321,7 @@ index ea4d8a6c1..2f950b525 100644
  #endif
 diff --git a/security/sandbox/chromium/sandbox/linux/system_headers/ppc64_linux_syscalls.h b/security/sandbox/chromium/sandbox/linux/system_headers/ppc64_linux_syscalls.h
 new file mode 100644
-index 000000000..ccacffe22
+index 0000000..ccacffe
 --- /dev/null
 +++ b/security/sandbox/chromium/sandbox/linux/system_headers/ppc64_linux_syscalls.h
 @@ -0,0 +1,12 @@
@@ -328,7 +339,7 @@ index 000000000..ccacffe22
 +#endif  // SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_SYSCALLS_H_
 diff --git a/security/sandbox/chromium/sandbox/linux/system_headers/ppc64_linux_ucontext.h b/security/sandbox/chromium/sandbox/linux/system_headers/ppc64_linux_ucontext.h
 new file mode 100644
-index 000000000..07728e087
+index 0000000..07728e0
 --- /dev/null
 +++ b/security/sandbox/chromium/sandbox/linux/system_headers/ppc64_linux_ucontext.h
 @@ -0,0 +1,12 @@
@@ -344,61 +355,8 @@ index 000000000..07728e087
 +//TODO: is it necessary to redefine ucontext on PPC64?
 +
 +#endif  // SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_UCONTEXT_H_
--- 
-2.35.1
-
-From b243c82be4c37369bab8a93a7b5628100d772750 Mon Sep 17 00:00:00 2001
-From: Marcus Comstedt <marcus@mc.pp.se>
-Date: Sun, 28 Apr 2019 15:22:43 +0200
-Subject: [PATCH 2/3] sandbox: Fix SECCOMP_*_[LM]SB_IDX for ppc64
-
----
- .../chromium/sandbox/linux/bpf_dsl/seccomp_macros.h   | 11 +++++++++++
- 1 file changed, 11 insertions(+)
-
-diff --git a/security/sandbox/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h b/security/sandbox/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
-index e50b31425..5d93dd5e4 100644
---- a/security/sandbox/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
-+++ b/security/sandbox/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
-@@ -315,6 +315,7 @@ typedef struct pt_regs regs_struct;
- 
- #define SECCOMP_NR_IDX (offsetof(struct arch_seccomp_data, nr))
- #define SECCOMP_ARCH_IDX (offsetof(struct arch_seccomp_data, arch))
-+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
- #define SECCOMP_IP_MSB_IDX \
-   (offsetof(struct arch_seccomp_data, instruction_pointer) + 4)
- #define SECCOMP_IP_LSB_IDX \
-@@ -323,6 +324,16 @@ typedef struct pt_regs regs_struct;
-   (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 4)
- #define SECCOMP_ARG_LSB_IDX(nr) \
-   (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 0)
-+#else
-+#define SECCOMP_IP_MSB_IDX \
-+  (offsetof(struct arch_seccomp_data, instruction_pointer) + 0)
-+#define SECCOMP_IP_LSB_IDX \
-+  (offsetof(struct arch_seccomp_data, instruction_pointer) + 4)
-+#define SECCOMP_ARG_MSB_IDX(nr) \
-+  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 0)
-+#define SECCOMP_ARG_LSB_IDX(nr) \
-+  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 4)
-+#endif
- 
- #define SECCOMP_PT_RESULT(_regs) (_regs).gpr[3]
- #define SECCOMP_PT_SYSCALL(_regs) (_regs).gpr[0]
--- 
-2.35.1
-
-From f845bd26f594c10564f41c544511ccd527945bb0 Mon Sep 17 00:00:00 2001
-From: Marcus Comstedt <marcus@mc.pp.se>
-Date: Tue, 29 Mar 2022 16:17:54 +0200
-Subject: [PATCH 3/3] sandbox: Add SANDBOX_ARCH_NAME for ppc64
-
----
- security/sandbox/linux/reporter/SandboxReporter.cpp | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/security/sandbox/linux/reporter/SandboxReporter.cpp b/security/sandbox/linux/reporter/SandboxReporter.cpp
-index 49cb285e8..4f62cbb03 100644
+index 6403c05..3b357dd 100644
 --- a/security/sandbox/linux/reporter/SandboxReporter.cpp
 +++ b/security/sandbox/linux/reporter/SandboxReporter.cpp
 @@ -26,6 +26,8 @@

--- a/seamonkey/1016_seamonkey-2.53.11-add_missing_global_mutex_for_ppc64.patch
+++ b/seamonkey/1016_seamonkey-2.53.11-add_missing_global_mutex_for_ppc64.patch
@@ -9,12 +9,12 @@ It is somehow needed by webrtc.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/ipc/chromium/moz.build b/ipc/chromium/moz.build
-index d5a52786d..c375ebb0f 100644
+index 5d7d811..18cd769 100644
 --- a/ipc/chromium/moz.build
 +++ b/ipc/chromium/moz.build
-@@ -138,7 +138,7 @@ if os_bsd or os_linux:
-             'src/base/message_pump_glib.cc',
-         ]
+@@ -133,7 +133,7 @@ if os_solaris:
+         'src/base/time_posix.cc',
+     ]
  
 -if not CONFIG['INTEL_ARCHITECTURE'] and CONFIG['CPU_ARCH'] not in ('arm', 'aarch64', 'mips32', 'mips64', 'ppc', 'ppc64'):
 +if not CONFIG['INTEL_ARCHITECTURE'] and CONFIG['CPU_ARCH'] not in ('arm', 'aarch64', 'mips32', 'mips64', 'ppc'):

--- a/seamonkey/1017_seamonkey-2.53.11-disable_JIT-specific_signal_handling_when_there_is_no_JIT.patch
+++ b/seamonkey/1017_seamonkey-2.53.11-disable_JIT-specific_signal_handling_when_there_is_no_JIT.patch
@@ -7,11 +7,11 @@ Subject: [PATCH] Don't use JIT signal handlers if no JIT
  js/src/wasm/WasmSignalHandlers.cpp | 4 ++++
  1 file changed, 4 insertions(+)
 
-diff --git a/js/src/wasm/WasmSignalHandlers.cpp b/js/src/wasm/WasmSignalHandlers.cpp
-index b14d47346..aaac36f2e 100644
---- a/js/src/wasm/WasmSignalHandlers.cpp
+diff --git a/js/src/wasm/WasmSignalHandlers.cpp.orig b/js/src/wasm/WasmSignalHandlers.cpp
+index 20d0268..d4fee57 100644
+--- a/js/src/wasm/WasmSignalHandlers.cpp.orig
 +++ b/js/src/wasm/WasmSignalHandlers.cpp
-@@ -1652,6 +1652,8 @@ ProcessHasSignalHandlers()
+@@ -1691,6 +1691,8 @@ ProcessHasSignalHandlers()
  bool
  wasm::EnsureSignalHandlers(JSContext* cx)
  {
@@ -20,7 +20,7 @@ index b14d47346..aaac36f2e 100644
      // Nothing to do if the platform doesn't support it.
      if (!ProcessHasSignalHandlers())
          return true;
-@@ -1660,6 +1662,8 @@ wasm::EnsureSignalHandlers(JSContext* cx)
+@@ -1699,6 +1701,8 @@ wasm::EnsureSignalHandlers(JSContext* cx)
      // On OSX, each JSContext which runs wasm gets its own handler thread.
      if (!cx->wasmMachExceptionHandler.installed() && !cx->wasmMachExceptionHandler.install(cx))
          return false;

--- a/seamonkey/2000_system_harfbuzz.patch
+++ b/seamonkey/2000_system_harfbuzz.patch
@@ -1,7 +1,8 @@
-diff -urN seamonkey-2.53.17.orig/config/system-headers.mozbuild seamonkey-2.53.17/config/system-headers.mozbuild
---- seamonkey-2.53.17.orig/config/system-headers.mozbuild	2023-06-10 12:40:55.000000000 +0200
-+++ seamonkey-2.53.17/config/system-headers.mozbuild	2023-08-05 21:46:23.712086050 +0200
-@@ -1321,6 +1321,13 @@
+diff --git a/config/system-headers.mozbuild b/config/system-headers.mozbuild
+index 46d67a3..de5941e 100644
+--- a/config/system-headers.mozbuild
++++ b/config/system-headers.mozbuild
+@@ -1325,6 +1325,13 @@ if CONFIG['MOZ_SYSTEM_ICU']:
          'unicode/utypes.h',
      ]
  
@@ -15,10 +16,11 @@ diff -urN seamonkey-2.53.17.orig/config/system-headers.mozbuild seamonkey-2.53.1
  if CONFIG['MOZ_WAYLAND']:
      system_headers += [
          'wayland-util.h',
-diff -urN seamonkey-2.53.17.orig/dom/base/moz.build seamonkey-2.53.17/dom/base/moz.build
---- seamonkey-2.53.17.orig/dom/base/moz.build	2023-06-10 12:40:55.000000000 +0200
-+++ seamonkey-2.53.17/dom/base/moz.build	2023-08-05 21:47:16.355326861 +0200
-@@ -472,6 +472,9 @@
+diff --git a/dom/base/moz.build b/dom/base/moz.build
+index 5dc9cd1..f5d7c59 100644
+--- a/dom/base/moz.build
++++ b/dom/base/moz.build
+@@ -474,6 +474,9 @@ if CONFIG['MOZ_BUILD_APP'] in ['browser', 'mobile/android', 'xulrunner']:
  if CONFIG['MOZ_X11']:
      CXXFLAGS += CONFIG['TK_CFLAGS']
  
@@ -28,10 +30,11 @@ diff -urN seamonkey-2.53.17.orig/dom/base/moz.build seamonkey-2.53.17/dom/base/m
  GeneratedFile('UseCounterList.h', script='gen-usecounters.py',
                entry_point='use_counter_list', inputs=['UseCounters.conf'])
  
-diff -urN seamonkey-2.53.17.orig/gfx/harfbuzz/README-mozilla seamonkey-2.53.17/gfx/harfbuzz/README-mozilla
---- seamonkey-2.53.17.orig/gfx/harfbuzz/README-mozilla	2021-10-26 18:49:54.000000000 +0200
-+++ seamonkey-2.53.17/gfx/harfbuzz/README-mozilla	2023-08-05 21:48:19.493014374 +0200
-@@ -21,3 +21,8 @@
+diff --git a/gfx/harfbuzz/README-mozilla b/gfx/harfbuzz/README-mozilla
+index 1a516cd..97b0912 100644
+--- a/gfx/harfbuzz/README-mozilla
++++ b/gfx/harfbuzz/README-mozilla
+@@ -21,3 +21,8 @@ from within the gfx/harfbuzz directory.
  
  If the collection of source files changes, manual updates to moz.build may be
  needed as we don't use the upstream makefiles.
@@ -40,10 +43,11 @@ diff -urN seamonkey-2.53.17.orig/gfx/harfbuzz/README-mozilla seamonkey-2.53.17/g
 +Make sure to keep pkg-config version check within toolkit/moz.configure in sync
 +with checkout version or increment latest tag by one if it's not based
 +on upstream release.
-diff -urN seamonkey-2.53.17.orig/gfx/moz.build seamonkey-2.53.17/gfx/moz.build
---- seamonkey-2.53.17.orig/gfx/moz.build	2020-02-18 00:37:51.000000000 +0100
-+++ seamonkey-2.53.17/gfx/moz.build	2023-08-05 21:49:14.718365101 +0200
-@@ -10,6 +10,9 @@
+diff --git a/gfx/moz.build b/gfx/moz.build
+index fb1da17..f8fc0f9 100644
+--- a/gfx/moz.build
++++ b/gfx/moz.build
+@@ -10,6 +10,9 @@ with Files('**'):
  if CONFIG['MOZ_TREE_CAIRO']:
      DIRS += ['cairo']
  
@@ -53,7 +57,7 @@ diff -urN seamonkey-2.53.17.orig/gfx/moz.build seamonkey-2.53.17/gfx/moz.build
  DIRS += [
      '2d',
      'ycbcr',
-@@ -19,7 +22,6 @@
+@@ -19,7 +22,6 @@ DIRS += [
      'gl',
      'layers',
      'graphite2/src',
@@ -61,10 +65,11 @@ diff -urN seamonkey-2.53.17.orig/gfx/moz.build seamonkey-2.53.17/gfx/moz.build
      'ots/src',
      'thebes',
      'ipc',
-diff -urN seamonkey-2.53.17.orig/gfx/skia/generate_mozbuild.py seamonkey-2.53.17/gfx/skia/generate_mozbuild.py
---- seamonkey-2.53.17.orig/gfx/skia/generate_mozbuild.py	2023-06-10 12:40:56.000000000 +0200
-+++ seamonkey-2.53.17/gfx/skia/generate_mozbuild.py	2023-08-05 21:50:07.481611012 +0200
-@@ -149,6 +149,9 @@
+diff --git a/gfx/skia/generate_mozbuild.py b/gfx/skia/generate_mozbuild.py
+index e1e326d..7cf4e1c 100755
+--- a/gfx/skia/generate_mozbuild.py
++++ b/gfx/skia/generate_mozbuild.py
+@@ -149,6 +149,9 @@ if CONFIG['CC_TYPE'] in ('clang', 'clang-cl'):
          '-Wno-unused-private-field',
      ]
  
@@ -74,10 +79,11 @@ diff -urN seamonkey-2.53.17.orig/gfx/skia/generate_mozbuild.py seamonkey-2.53.17
  if CONFIG['MOZ_WIDGET_TOOLKIT'] in ('gtk', 'android'):
      CXXFLAGS += CONFIG['MOZ_CAIRO_CFLAGS']
      CXXFLAGS += CONFIG['CAIRO_FT_CFLAGS']
-diff -urN seamonkey-2.53.17.orig/gfx/thebes/moz.build seamonkey-2.53.17/gfx/thebes/moz.build
---- seamonkey-2.53.17.orig/gfx/thebes/moz.build	2023-06-10 12:40:56.000000000 +0200
-+++ seamonkey-2.53.17/gfx/thebes/moz.build	2023-08-05 21:51:03.409991655 +0200
-@@ -268,6 +268,9 @@
+diff --git a/gfx/thebes/moz.build b/gfx/thebes/moz.build
+index 0ad93da..c8e7b6c 100644
+--- a/gfx/thebes/moz.build
++++ b/gfx/thebes/moz.build
+@@ -267,6 +267,9 @@ LOCAL_INCLUDES += CONFIG['SKIA_INCLUDES']
  
  DEFINES['GRAPHITE2_STATIC'] = True
  
@@ -87,10 +93,11 @@ diff -urN seamonkey-2.53.17.orig/gfx/thebes/moz.build seamonkey-2.53.17/gfx/theb
  if CONFIG['CC_TYPE'] == 'clang':
      # Suppress warnings from Skia header files.
      SOURCES['gfxPlatform.cpp'].flags += ['-Wno-implicit-fallthrough']
-diff -urN seamonkey-2.53.17.orig/intl/unicharutil/util/moz.build seamonkey-2.53.17/intl/unicharutil/util/moz.build
---- seamonkey-2.53.17.orig/intl/unicharutil/util/moz.build	2020-08-10 13:30:34.000000000 +0200
-+++ seamonkey-2.53.17/intl/unicharutil/util/moz.build	2023-08-05 21:51:47.571871443 +0200
-@@ -25,4 +25,7 @@
+diff --git a/intl/unicharutil/util/moz.build b/intl/unicharutil/util/moz.build
+index b12b3bb..05f5ccf 100644
+--- a/intl/unicharutil/util/moz.build
++++ b/intl/unicharutil/util/moz.build
+@@ -25,4 +25,7 @@ UNIFIED_SOURCES += [
      'nsUnicodeProperties.cpp',
  ]
  
@@ -98,10 +105,11 @@ diff -urN seamonkey-2.53.17.orig/intl/unicharutil/util/moz.build seamonkey-2.53.
 +    CXXFLAGS += CONFIG['MOZ_HARFBUZZ_CFLAGS']
 +
  FINAL_LIBRARY = 'xul'
-diff -urN seamonkey-2.53.17.orig/netwerk/dns/moz.build seamonkey-2.53.17/netwerk/dns/moz.build
---- seamonkey-2.53.17.orig/netwerk/dns/moz.build	2023-06-10 12:41:20.000000000 +0200
-+++ seamonkey-2.53.17/netwerk/dns/moz.build	2023-08-05 21:52:48.478463988 +0200
-@@ -61,6 +61,9 @@
+diff --git a/netwerk/dns/moz.build b/netwerk/dns/moz.build
+index 561f310..be56e8d 100644
+--- a/netwerk/dns/moz.build
++++ b/netwerk/dns/moz.build
+@@ -61,6 +61,9 @@ LOCAL_INCLUDES += [
      '/netwerk/base',
  ]
  
@@ -111,10 +119,11 @@ diff -urN seamonkey-2.53.17.orig/netwerk/dns/moz.build seamonkey-2.53.17/netwerk
  USE_LIBS += ['icu']
  
  if CONFIG['CC_TYPE'] in ('clang', 'gcc'):
-diff -urN seamonkey-2.53.17.orig/toolkit/library/moz.build seamonkey-2.53.17/toolkit/library/moz.build
---- seamonkey-2.53.17.orig/toolkit/library/moz.build	2023-06-10 12:41:26.000000000 +0200
-+++ seamonkey-2.53.17/toolkit/library/moz.build	2023-08-05 21:53:41.312712928 +0200
-@@ -226,6 +226,9 @@
+diff --git a/toolkit/library/moz.build b/toolkit/library/moz.build
+index 693242e..3462616 100644
+--- a/toolkit/library/moz.build
++++ b/toolkit/library/moz.build
+@@ -221,6 +221,9 @@ if CONFIG['MOZ_SYSTEM_JPEG']:
  if CONFIG['MOZ_SYSTEM_PNG']:
      OS_LIBS += CONFIG['MOZ_PNG_LIBS']
  
@@ -124,10 +133,11 @@ diff -urN seamonkey-2.53.17.orig/toolkit/library/moz.build seamonkey-2.53.17/too
  if CONFIG['MOZ_SYSTEM_WEBP']:
      OS_LIBS += CONFIG['MOZ_WEBP_LIBS']
  
-diff -urN seamonkey-2.53.17.orig/toolkit/moz.configure seamonkey-2.53.17/toolkit/moz.configure
---- seamonkey-2.53.17.orig/toolkit/moz.configure	2023-07-28 00:15:02.000000000 +0200
-+++ seamonkey-2.53.17/toolkit/moz.configure	2023-08-05 21:54:45.306436883 +0200
-@@ -933,6 +933,21 @@
+diff --git a/toolkit/moz.configure b/toolkit/moz.configure
+index 2a29d3d..d42ce99 100644
+--- a/toolkit/moz.configure
++++ b/toolkit/moz.configure
+@@ -927,6 +927,21 @@ add_old_configure_assignment('FT2_LIBS',
  add_old_configure_assignment('FT2_CFLAGS',
                               ft2_info.cflags)
  

--- a/seamonkey/2001_system_graphite2.patch
+++ b/seamonkey/2001_system_graphite2.patch
@@ -1,7 +1,8 @@
-diff -urN seamonkey-2.53.17.orig/config/system-headers.mozbuild seamonkey-2.53.17/config/system-headers.mozbuild
---- seamonkey-2.53.17.orig/config/system-headers.mozbuild	2023-08-05 22:30:23.030431238 +0200
-+++ seamonkey-2.53.17/config/system-headers.mozbuild	2023-08-05 22:47:21.882799714 +0200
-@@ -1327,6 +1327,12 @@
+diff --git a/config/system-headers.mozbuild b/config/system-headers.mozbuild
+index de5941e..86d6b60 100644
+--- a/config/system-headers.mozbuild
++++ b/config/system-headers.mozbuild
+@@ -1332,6 +1332,12 @@ if CONFIG['MOZ_SYSTEM_HARFBUZZ']:
          'harfbuzz/hb.h'
      ]
  
@@ -14,9 +15,10 @@ diff -urN seamonkey-2.53.17.orig/config/system-headers.mozbuild seamonkey-2.53.1
  if CONFIG['MOZ_WAYLAND']:
      system_headers += [
          'wayland-util.h',
-diff -urN seamonkey-2.53.17.orig/gfx/graphite2/moz-gr-update.sh seamonkey-2.53.17/gfx/graphite2/moz-gr-update.sh
---- seamonkey-2.53.17.orig/gfx/graphite2/moz-gr-update.sh	2023-08-05 22:42:23.914116379 +0200
-+++ seamonkey-2.53.17/gfx/graphite2/moz-gr-update.sh	2023-08-05 22:30:23.156436601 +0200
+diff --git a/gfx/graphite2/moz-gr-update.sh b/gfx/graphite2/moz-gr-update.sh
+index b91d9c1..a97e6eb 100755
+--- a/gfx/graphite2/moz-gr-update.sh
++++ b/gfx/graphite2/moz-gr-update.sh
 @@ -1,6 +1,7 @@
  #!/bin/bash
  
@@ -25,7 +27,7 @@ diff -urN seamonkey-2.53.17.orig/gfx/graphite2/moz-gr-update.sh seamonkey-2.53.1
  
  # This script lives in gfx/graphite2, along with the library source,
  # but must be run from the top level of the mozilla-central tree.
-@@ -37,12 +38,16 @@
+@@ -37,12 +38,16 @@ echo "See" $0 "for update procedure." >> gfx/graphite2/README.mozilla
  #find gfx/graphite2/ -name "*.cpp" -exec perl -p -i -e "s/<cstdio>/<stdio.h>/;s/Windows.h/windows.h/;" {} \;
  #find gfx/graphite2/ -name "*.h" -exec perl -p -i -e "s/<cstdio>/<stdio.h>/;s/Windows.h/windows.h/;" {} \;
  
@@ -43,10 +45,11 @@ diff -urN seamonkey-2.53.17.orig/gfx/graphite2/moz-gr-update.sh seamonkey-2.53.1
  
  echo
  echo If gfx/graphite2/src/files.mk has changed, please make corresponding
-diff -urN seamonkey-2.53.17.orig/gfx/moz.build seamonkey-2.53.17/gfx/moz.build
---- seamonkey-2.53.17.orig/gfx/moz.build	2023-08-05 22:43:10.178085653 +0200
-+++ seamonkey-2.53.17/gfx/moz.build	2023-08-05 22:30:23.173437325 +0200
-@@ -10,6 +10,9 @@
+diff --git a/gfx/moz.build b/gfx/moz.build
+index f8fc0f9..f9112c3 100644
+--- a/gfx/moz.build
++++ b/gfx/moz.build
+@@ -10,6 +10,9 @@ with Files('**'):
  if CONFIG['MOZ_TREE_CAIRO']:
      DIRS += ['cairo']
  
@@ -56,7 +59,7 @@ diff -urN seamonkey-2.53.17.orig/gfx/moz.build seamonkey-2.53.17/gfx/moz.build
  if not CONFIG['MOZ_SYSTEM_HARFBUZZ']:
      DIRS += ['harfbuzz/src']
  
-@@ -21,7 +24,6 @@
+@@ -21,7 +24,6 @@ DIRS += [
      'qcms',
      'gl',
      'layers',
@@ -64,10 +67,11 @@ diff -urN seamonkey-2.53.17.orig/gfx/moz.build seamonkey-2.53.17/gfx/moz.build
      'ots/src',
      'thebes',
      'ipc',
-diff -urN seamonkey-2.53.17.orig/gfx/thebes/moz.build seamonkey-2.53.17/gfx/thebes/moz.build
---- seamonkey-2.53.17.orig/gfx/thebes/moz.build	2023-08-05 22:44:19.949055518 +0200
-+++ seamonkey-2.53.17/gfx/thebes/moz.build	2023-08-05 22:30:23.174437368 +0200
-@@ -266,7 +266,10 @@
+diff --git a/gfx/thebes/moz.build b/gfx/thebes/moz.build
+index c8e7b6c..5ca2df3 100644
+--- a/gfx/thebes/moz.build
++++ b/gfx/thebes/moz.build
+@@ -265,7 +265,10 @@ if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gtk':
  
  LOCAL_INCLUDES += CONFIG['SKIA_INCLUDES']
  
@@ -79,13 +83,15 @@ diff -urN seamonkey-2.53.17.orig/gfx/thebes/moz.build seamonkey-2.53.17/gfx/theb
  
  if CONFIG['MOZ_SYSTEM_HARFBUZZ']:
      CXXFLAGS += CONFIG['MOZ_HARFBUZZ_CFLAGS']
-diff -urN seamonkey-2.53.17.orig/old-configure.in seamonkey-2.53.17/old-configure.in
---- seamonkey-2.53.17.orig/old-configure.in	2023-08-05 22:45:00.790793992 +0200
-+++ seamonkey-2.53.17/old-configure.in	2023-08-05 22:30:23.175437410 +0200
-@@ -2771,6 +2771,27 @@
+diff --git a/old-configure.in b/old-configure.in
+index 9594353..6b19a6d 100644
+--- a/old-configure.in
++++ b/old-configure.in
+@@ -2518,6 +2518,27 @@ dnl ========================================================
+ 
  AC_SUBST(MOZ_LINUX_32_SSE2_STARTUP_ERROR)
  
- dnl ========================================================
++dnl ========================================================
 +dnl Check for graphite2
 +dnl ========================================================
 +if test -n "$MOZ_SYSTEM_GRAPHITE2"; then
@@ -106,14 +112,14 @@ diff -urN seamonkey-2.53.17.orig/old-configure.in seamonkey-2.53.17/old-configur
 +    CFLAGS=$_SAVE_CFLAGS
 +fi
 +
-+dnl ========================================================
+ dnl ========================================================
  dnl Check for pixman and cairo
  dnl ========================================================
- 
-diff -urN seamonkey-2.53.17.orig/toolkit/library/moz.build seamonkey-2.53.17/toolkit/library/moz.build
---- seamonkey-2.53.17.orig/toolkit/library/moz.build	2023-08-05 22:45:51.487951977 +0200
-+++ seamonkey-2.53.17/toolkit/library/moz.build	2023-08-05 22:30:23.279441839 +0200
-@@ -226,6 +226,9 @@
+diff --git a/toolkit/library/moz.build b/toolkit/library/moz.build
+index 3462616..6b4e230 100644
+--- a/toolkit/library/moz.build
++++ b/toolkit/library/moz.build
+@@ -221,6 +221,9 @@ if CONFIG['MOZ_SYSTEM_JPEG']:
  if CONFIG['MOZ_SYSTEM_PNG']:
      OS_LIBS += CONFIG['MOZ_PNG_LIBS']
  
@@ -123,10 +129,11 @@ diff -urN seamonkey-2.53.17.orig/toolkit/library/moz.build seamonkey-2.53.17/too
  if CONFIG['MOZ_SYSTEM_HARFBUZZ']:
      OS_LIBS += CONFIG['MOZ_HARFBUZZ_LIBS']
  
-diff -urN seamonkey-2.53.17.orig/toolkit/moz.configure seamonkey-2.53.17/toolkit/moz.configure
---- seamonkey-2.53.17.orig/toolkit/moz.configure	2023-08-05 22:46:22.745282466 +0200
-+++ seamonkey-2.53.17/toolkit/moz.configure	2023-08-05 22:30:23.281441924 +0200
-@@ -933,6 +933,19 @@
+diff --git a/toolkit/moz.configure b/toolkit/moz.configure
+index d42ce99..39b7d0b 100644
+--- a/toolkit/moz.configure
++++ b/toolkit/moz.configure
+@@ -927,6 +927,19 @@ add_old_configure_assignment('FT2_LIBS',
  add_old_configure_assignment('FT2_CFLAGS',
                               ft2_info.cflags)
  

--- a/seamonkey/2002_bmo-1559213-Support-system-av1.patch
+++ b/seamonkey/2002_bmo-1559213-Support-system-av1.patch
@@ -15,10 +15,10 @@ Signed-off-by: Thomas Deutschmann <whissi@gentoo.org>
  4 files changed, 34 insertions(+), 3 deletions(-)
 
 diff --git a/config/external/moz.build b/config/external/moz.build
-index 70aa339308..b1981f9ff6 100644
+index 8088c97..00de6fd 100644
 --- a/config/external/moz.build
 +++ b/config/external/moz.build
-@@ -40,8 +40,9 @@ if not CONFIG['MOZ_SYSTEM_LIBVPX']:
+@@ -32,8 +32,9 @@ if not CONFIG['MOZ_SYSTEM_LIBVPX']:
      external_dirs += ['media/libvpx']
  
  if CONFIG['MOZ_AV1']:
@@ -31,10 +31,10 @@ index 70aa339308..b1981f9ff6 100644
  if not CONFIG['MOZ_SYSTEM_PNG']:
      external_dirs += ['media/libpng']
 diff --git a/config/system-headers.mozbuild b/config/system-headers.mozbuild
-index 854e6262fe..bed1169b42 100644
+index 86d6b60..33f671f 100644
 --- a/config/system-headers.mozbuild
 +++ b/config/system-headers.mozbuild
-@@ -1296,6 +1296,14 @@ if CONFIG['MOZ_ENABLE_LIBPROXY']:
+@@ -1288,6 +1288,14 @@ if CONFIG['MOZ_ENABLE_LIBPROXY']:
          'proxy.h',
      ]
  
@@ -50,10 +50,10 @@ index 854e6262fe..bed1169b42 100644
      system_headers += [
          'vpx_mem/vpx_mem.h',
 diff --git a/dom/media/platforms/moz.build b/dom/media/platforms/moz.build
-index 9dcc527729..fd1283a135 100644
+index 81f1533..3703808 100644
 --- a/dom/media/platforms/moz.build
 +++ b/dom/media/platforms/moz.build
-@@ -81,6 +81,11 @@ if CONFIG['MOZ_AV1']:
+@@ -74,6 +74,11 @@ if CONFIG['MOZ_AV1']:
          'agnostic/AOMDecoder.cpp',
          'agnostic/DAV1DDecoder.cpp',
      ]
@@ -63,13 +63,13 @@ index 9dcc527729..fd1283a135 100644
 +        CXXFLAGS += CONFIG['MOZ_SYSTEM_LIBDAV1D_CFLAGS']
 +        OS_LIBS += CONFIG['MOZ_SYSTEM_LIBDAV1D_LIBS']
  
- if CONFIG['MOZ_OMX']:
-     EXPORTS += [
+ if CONFIG['MOZ_APPLEMEDIA']:
+   EXPORTS += [
 diff --git a/toolkit/moz.configure b/toolkit/moz.configure
-index daa3d1f454..fbb8d9eddb 100644
+index 39b7d0b..c1a0c88 100644
 --- a/toolkit/moz.configure
 +++ b/toolkit/moz.configure
-@@ -491,7 +491,23 @@ def av1(value):
+@@ -408,7 +408,23 @@ def av1(value):
      if value:
          return True
  
@@ -92,9 +92,9 @@ index daa3d1f454..fbb8d9eddb 100644
 +
 +@depends(target, nasm_version, when=av1 & depends(system_av1)(lambda v: not v) & compile_environment)
  def dav1d_asm(target, nasm_version):
-     if target.cpu == 'aarch64':
-         return True
-@@ -506,6 +522,7 @@ set_config('MOZ_DAV1D_ASM', dav1d_asm)
+     if target.os != 'Android':
+         if target.cpu == 'aarch64':
+@@ -424,6 +440,7 @@ set_config('MOZ_DAV1D_ASM', dav1d_asm)
  set_define('MOZ_DAV1D_ASM', dav1d_asm)
  set_config('MOZ_AV1', av1)
  set_define('MOZ_AV1', av1)

--- a/seamonkey/2019_fix_import_location.patch
+++ b/seamonkey/2019_fix_import_location.patch
@@ -1,12 +1,13 @@
-diff -urN seamonkey-2.53.14.orig/build/moz.configure/init.configure seamonkey-2.53.14/build/moz.configure/init.configure
---- seamonkey-2.53.14.orig/build/moz.configure/init.configure	2022-08-24 21:55:10.000000000 +0200
-+++ seamonkey-2.53.14/build/moz.configure/init.configure	2022-10-01 23:19:03.579226107 +0200
-@@ -259,6 +259,8 @@
-     # necessary modules for find_program.
-     if normsep(sys.executable) != normsep(manager.python_path):
-         sys.path.insert(
-+            0, os.path.join(topsrcdir, 'testing', 'mozbase', 'mozfile'))
+diff --git a/build/moz.configure/init.configure b/build/moz.configure/init.configure
+index 7e1eed4..e921e3b 100644
+--- a/build/moz.configure/init.configure
++++ b/build/moz.configure/init.configure
+@@ -310,6 +310,8 @@ def virtualenv_python3(env_python, build_env, mozconfig, help):
+     try:
+         import mozfile
+     except ImportError:
 +        sys.path.insert(
-             0, os.path.join(topsrcdir, 'third_party', 'python', 'backports'))
- 
-     if python:
++            0, os.path.join(topsrcdir, 'testing', 'mozbase', 'mozfile'))
+         sys.path.insert(
+             0, os.path.join(topsrcdir, 'testing', 'mozbase', 'mozfile'))
+         sys.path.insert(

--- a/seamonkey/6003_fix_syscall_wrappers_on_musl.patch
+++ b/seamonkey/6003_fix_syscall_wrappers_on_musl.patch
@@ -19,11 +19,11 @@ Signed-off-by: Samuel Holland <samuel@sholland.org>
  1 file changed, 7 insertions(+)
 
 diff --git a/toolkit/crashreporter/google-breakpad/src/third_party/lss/linux_syscall_support.h b/toolkit/crashreporter/google-breakpad/src/third_party/lss/linux_syscall_support.h
-index 162a27e77..d46e8c9be 100644
+index a2b8a62..e249b15 100644
 --- a/toolkit/crashreporter/google-breakpad/src/third_party/lss/linux_syscall_support.h
 +++ b/toolkit/crashreporter/google-breakpad/src/third_party/lss/linux_syscall_support.h
-@@ -143,6 +143,13 @@ extern "C" {
- # undef lstat64
+@@ -171,6 +171,13 @@ extern "C" {
+ # undef __NR_waitpid
  #endif
  
 +#ifdef pread64

--- a/seamonkey/6005_musl_memory_report.patch
+++ b/seamonkey/6005_musl_memory_report.patch
@@ -4,7 +4,7 @@ Only use system heap reporter with glibc
 
 --- a/xpcom/base/nsMemoryReporterManager.cpp
 +++ b/xpcom/base/nsMemoryReporterManager.cpp
-@@ -644,6 +644,7 @@ static MOZ_MUST_USE nsresult PrivateDistinguishedAmount(int64_t* aN) {
+@@ -702,6 +702,7 @@ PrivateDistinguishedAmount(int64_t* aN)
    return NS_OK;
  }
  
@@ -12,11 +12,11 @@ Only use system heap reporter with glibc
  #define HAVE_SYSTEM_HEAP_REPORTER 1
  // Windows can have multiple separate heaps. During testing there were multiple
  // heaps present but the non-default ones had sizes no more than a few 10s of
-@@ -700,6 +701,7 @@ static MOZ_MUST_USE nsresult SystemHeapSize(int64_t* aSizeOut) {
+@@ -760,6 +761,7 @@ SystemHeapSize(int64_t* aSizeOut)
    *aSizeOut = heapsSize;
    return NS_OK;
  }
 +#endif
  
- struct SegmentKind {
-   DWORD mState;
+ struct SegmentKind
+ {


### PR DESCRIPTION
these are purely cosmetic changes, wanted to do that once 2.53.19 is released and was surprised by your speedy pullrequest. this will stop all fuzzing in emerge: 

```
 * Applying patches from /var/tmp/portage/www-client/seamonkey-2.53.19/work/gentoo-seamonkey-patches-2.53.19/seamonkey ...
 *   1000_fix-preferences-gentoo.patch ...                                                                                                                                       [ ok ]
 *   1001_gentoo_prefs.patch ...                                                                                                                                                 [ ok ]
 *   1002_drop_build_id.patch ...                                                                                                                                                [ ok ]
 *   1003_gentoo_specific_pgo.patch ...                                                                                                                                          [ ok ]
 *   1005_fix_fortify_sources.patch ...                                                                                                                                          [ ok ]
 *   1007_re-add_system_sqlite.patch ...                                                                                                                                         [ ok ]
 *   1014_seamonkey-2.53.11-fix_sandbox_on_ppc64.patch ...                                                                                                                       [ ok ]
 *   1016_seamonkey-2.53.11-add_missing_global_mutex_for_ppc64.patch ...                                                                                                         [ ok ]
 *   1017_seamonkey-2.53.11-disable_JIT-specific_signal_handling_when_there_is_no_JIT.patch ...                                                                                  [ ok ]
 *   2000_system_harfbuzz.patch ...                                                                                                                                              [ ok ]
 *   2001_system_graphite2.patch ...                                                                                                                                             [ ok ]
 *   2002_bmo-1559213-Support-system-av1.patch ...                                                                                                                               [ ok ]
 *   2004_fix_lto_builds.patch ...                                                                                                                                               [ ok ]
 *   2006_musl_sys_auxv.patch ...                                                                                                                                                [ ok ]
 *   2011_missing-errno_h-in-SandboxOpenedFiles_cpp.patch ...                                                                                                                    [ ok ]
 *   2019_fix_import_location.patch ...                                                                                                                                          [ ok ]
 *   2020_audioipc_padding_on_musl.patch ...                                                                                                                                     [ ok ]
 *   6001_add_missing_header_for_basename.patch ...                                                                                                                              [ ok ]
 *   6002_add_alternate_name_for_private_siginfo_struct_member.patch ...                                                                                                         [ ok ]
 *   6003_fix_syscall_wrappers_on_musl.patch ...                                                                                                                                 [ ok ]
 *   6005_musl_memory_report.patch ...                                                                                                                                           [ ok ]
 *   6006_musl_pthread_setname.patch ...                                                                                                                                         [ ok ]
 *   6007_musl_fix_tools.patch ...                                                                                                                                               [ ok ]
 *   6008_musl_fix_toolkit.patch ...                                                                                                                                             [ ok ]
 *   6009-fix-rust-1.78.0-mozbg1882209-127a1.patch ...                                                                                                                           [ ok ]
 * Applying 1009_seamonkey-2.53.3-system_libvpx-1.8.patch ...                                                                                                                    [ ok ]
 * Applying 2022-bmo-1862601-system-icu-74.patch ...                                                                                                                             [ ok ]
```