### PR TITLE
upstream patch for building with rust-1.95.0

### DIFF
--- a/seamonkey/6009-fix-rust-1.78.0-mozbg1882209-127a1.patch
+++ b/seamonkey/6009-fix-rust-1.78.0-mozbg1882209-127a1.patch
@@ -1,8 +1,21 @@
+# HG changeset patch
+# User Henri Sivonen <hsivonen@hsivonen.fi>
+# Date 1714462184 0
+# Node ID 1db2ef126a6a8555dbf50345e16492c977b42e92
+# Parent  787d9cd062412a42649a8c61619b95ab204ab571
+Bug 1882209 - Update encoding_rs to 0.8.34 to deal with rustc changes. r=glandium,supply-chain-reviewers
+
+Differential Revision: https://phabricator.services.mozilla.com/D207167
+
 diff --git a/.cargo/config.in b/.cargo/config.in
-index 194c93b..e48d128 100644
 --- a/.cargo/config.in
 +++ b/.cargo/config.in
-@@ -7,10 +7,10 @@ git = "https://github.com/servo/serde"
+@@ -2,15 +2,15 @@
+ registry = 'https://github.com/rust-lang/crates.io-index'
+ replace-with = 'vendored-sources'
+ 
+ [source."https://github.com/servo/serde"]
+ git = "https://github.com/servo/serde"
  branch = "deserialize_from_enums8"
  replace-with = "vendored-sources"
  
@@ -17,14 +30,17 @@ index 194c93b..e48d128 100644
  [source.vendored-sources]
  directory = '@top_srcdir@/third_party/rust'
 diff --git a/Cargo.lock b/Cargo.lock
-index ca85c35..41a5973 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -20,6 +20,15 @@ dependencies = [
-  "winapi 0.3.4",
+@@ -16,16 +16,25 @@ name = "ansi_term"
+ version = "0.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+ dependencies = [
+  "winapi 0.3.7",
  ]
  
-+[[package]]
+ [[package]]
 +name = "any_all_workaround"
 +version = "0.1.0"
 +source = "git+https://github.com/hsivonen/any_all_workaround?rev=7fb1b7034c9f172aade21ee1c8554e8d8a48af80#7fb1b7034c9f172aade21ee1c8554e8d8a48af80"
@@ -33,10 +49,21 @@ index ca85c35..41a5973 100644
 + "version_check",
 +]
 +
- [[package]]
++[[package]]
  name = "app_units"
  version = "0.7.0"
-@@ -608,12 +617,12 @@ dependencies = [
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9dadc668390b373e73e4abbfc1f07238b09a25858f2f39c06cebc6d8e141d774"
+ dependencies = [
+  "num-traits",
+  "serde",
+ ]
+@@ -605,22 +614,22 @@ version = "0.1.0"
+ dependencies = [
+  "encoding_rs",
+  "nserror",
+  "nsstring",
+ ]
  
  [[package]]
  name = "encoding_rs"
@@ -52,50 +79,83 @@ index ca85c35..41a5973 100644
  ]
  
  [[package]]
-@@ -1305,15 +1314,6 @@ dependencies = [
+ name = "env_logger"
+ version = "0.5.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+ dependencies = [
+@@ -1324,25 +1333,16 @@ name = "owning_ref"
+ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+ dependencies = [
   "stable_deref_trait",
  ]
  
--[[package]]
+ [[package]]
 -name = "packed_simd"
 -version = "0.3.9"
 -source = "git+https://github.com/hsivonen/packed_simd?rev=e588ceb568878e1a3156ea9ce551d5b63ef0cdc4#e588ceb568878e1a3156ea9ce551d5b63ef0cdc4"
 -dependencies = [
 - "cfg-if 1.0.0",
-- "num-traits 0.2.15",
+- "num-traits",
 -]
 -
- [[package]]
+-[[package]]
  name = "parking_lot"
- version = "0.6.3"
-@@ -2239,6 +2239,12 @@ version = "0.8.0"
+ version = "0.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
+ dependencies = [
+  "lock_api",
+  "parking_lot_core",
+  "rustc_version",
+@@ -2366,16 +2366,22 @@ checksum = "025ce40a007e1907e58d5bc1a594
+ 
+ [[package]]
+ name = "vec_map"
+ version = "0.8.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
  
-+[[package]]
+ [[package]]
 +name = "version_check"
 +version = "0.9.4"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 +
- [[package]]
++[[package]]
  name = "void"
  version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+ 
+ [[package]]
+ name = "walkdir"
+ version = "2.1.4"
 diff --git a/Cargo.toml b/Cargo.toml
-index 845d983..5153230 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -53,4 +53,4 @@ codegen-units = 1
+@@ -48,9 +48,9 @@ opt-level = 2
+ rpath = false
+ debug-assertions = false
+ panic = "abort"
+ codegen-units = 1
+ 
  [patch.crates-io]
  libudev-sys = { path = "dom/webauthn/libudev-sys" }
  serde_derive = { git = "https://github.com/servo/serde", branch = "deserialize_from_enums8" }
 -packed_simd = { git = "https://github.com/hsivonen/packed_simd", rev = "e588ceb568878e1a3156ea9ce551d5b63ef0cdc4" }
 +any_all_workaround = { git = "https://github.com/hsivonen/any_all_workaround", rev = "7fb1b7034c9f172aade21ee1c8554e8d8a48af80" }
 diff --git a/config/makefiles/rust.mk b/config/makefiles/rust.mk
-index ff3db19..17c735b 100644
 --- a/config/makefiles/rust.mk
 +++ b/config/makefiles/rust.mk
-@@ -66,7 +66,7 @@ ifeq (,$(filter 1.47.% 1.48.% 1.49.%,$(RUSTC_VERSION)))
+@@ -61,17 +61,17 @@ endif
+ endif
+ endif
+ 
+ ifndef RUSTC_BOOTSTRAP
+ ifeq (,$(filter 1.47.% 1.48.% 1.49.%,$(RUSTC_VERSION)))
  # RUSTC_BOOTSTRAP := gkrust_shared,qcms for later
  RUSTC_BOOTSTRAP := gkrust_shared
  ifdef MOZ_RUST_SIMD
@@ -104,17 +164,20 @@ index ff3db19..17c735b 100644
  endif
  export RUSTC_BOOTSTRAP
  endif
+ endif
+ 
+ ifdef CARGO_INCREMENTAL
+ export CARGO_INCREMENTAL
+ endif
 diff --git a/third_party/rust/any_all_workaround/.cargo-checksum.json b/third_party/rust/any_all_workaround/.cargo-checksum.json
 new file mode 100644
-index 0000000..8d16e68
 --- /dev/null
 +++ b/third_party/rust/any_all_workaround/.cargo-checksum.json
-@@ -0,0 +1 @@
+@@ -0,0 +1,1 @@
 +{"files":{"Cargo.toml":"f8c127449dc9432d404c21c99833e4617ab88a797445af249a7fe3c989985d6d","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"6485b8ed310d3f0340bf1ad1f47645069ce4069dcc6bb46c7d5c6faf41de1fdb","LICENSE-MIT-QCMS":"36d847ae882f6574ebc72f56a4f354e4f104fde4a584373496482e97d52d31bc","README.md":"4c617b8ced3a27b7edecf0e5e41ed451c04e88dab529e7a35fccc4e1551efbd7","build.rs":"56b29ab6da3e49075bfd0a7b690267c8016298bf0d332e2e68bbaf19decbbf71","src/lib.rs":"7118106690b9d25c5d0a3e2079feb83d76f1d434d0da36b9d0351806d27c850d"},"package":null}
 \ No newline at end of file
 diff --git a/third_party/rust/any_all_workaround/Cargo.toml b/third_party/rust/any_all_workaround/Cargo.toml
 new file mode 100644
-index 0000000..4b03a35
 --- /dev/null
 +++ b/third_party/rust/any_all_workaround/Cargo.toml
 @@ -0,0 +1,28 @@
@@ -146,17 +209,244 @@ index 0000000..4b03a35
 +
 +[build-dependencies]
 +version_check = "0.9"
-diff --git a/third_party/rust/packed_simd/LICENSE-APACHE b/third_party/rust/any_all_workaround/LICENSE-APACHE
-similarity index 100%
-rename from third_party/rust/packed_simd/LICENSE-APACHE
-rename to third_party/rust/any_all_workaround/LICENSE-APACHE
-diff --git a/third_party/rust/packed_simd/LICENSE-MIT b/third_party/rust/any_all_workaround/LICENSE-MIT
-similarity index 100%
-rename from third_party/rust/packed_simd/LICENSE-MIT
-rename to third_party/rust/any_all_workaround/LICENSE-MIT
+diff --git a/third_party/rust/any_all_workaround/LICENSE-APACHE b/third_party/rust/any_all_workaround/LICENSE-APACHE
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/any_all_workaround/LICENSE-APACHE
+@@ -0,0 +1,201 @@
++                              Apache License
++                        Version 2.0, January 2004
++                     http://www.apache.org/licenses/
++
++TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
++
++1. Definitions.
++
++   "License" shall mean the terms and conditions for use, reproduction,
++   and distribution as defined by Sections 1 through 9 of this document.
++
++   "Licensor" shall mean the copyright owner or entity authorized by
++   the copyright owner that is granting the License.
++
++   "Legal Entity" shall mean the union of the acting entity and all
++   other entities that control, are controlled by, or are under common
++   control with that entity. For the purposes of this definition,
++   "control" means (i) the power, direct or indirect, to cause the
++   direction or management of such entity, whether by contract or
++   otherwise, or (ii) ownership of fifty percent (50%) or more of the
++   outstanding shares, or (iii) beneficial ownership of such entity.
++
++   "You" (or "Your") shall mean an individual or Legal Entity
++   exercising permissions granted by this License.
++
++   "Source" form shall mean the preferred form for making modifications,
++   including but not limited to software source code, documentation
++   source, and configuration files.
++
++   "Object" form shall mean any form resulting from mechanical
++   transformation or translation of a Source form, including but
++   not limited to compiled object code, generated documentation,
++   and conversions to other media types.
++
++   "Work" shall mean the work of authorship, whether in Source or
++   Object form, made available under the License, as indicated by a
++   copyright notice that is included in or attached to the work
++   (an example is provided in the Appendix below).
++
++   "Derivative Works" shall mean any work, whether in Source or Object
++   form, that is based on (or derived from) the Work and for which the
++   editorial revisions, annotations, elaborations, or other modifications
++   represent, as a whole, an original work of authorship. For the purposes
++   of this License, Derivative Works shall not include works that remain
++   separable from, or merely link (or bind by name) to the interfaces of,
++   the Work and Derivative Works thereof.
++
++   "Contribution" shall mean any work of authorship, including
++   the original version of the Work and any modifications or additions
++   to that Work or Derivative Works thereof, that is intentionally
++   submitted to Licensor for inclusion in the Work by the copyright owner
++   or by an individual or Legal Entity authorized to submit on behalf of
++   the copyright owner. For the purposes of this definition, "submitted"
++   means any form of electronic, verbal, or written communication sent
++   to the Licensor or its representatives, including but not limited to
++   communication on electronic mailing lists, source code control systems,
++   and issue tracking systems that are managed by, or on behalf of, the
++   Licensor for the purpose of discussing and improving the Work, but
++   excluding communication that is conspicuously marked or otherwise
++   designated in writing by the copyright owner as "Not a Contribution."
++
++   "Contributor" shall mean Licensor and any individual or Legal Entity
++   on behalf of whom a Contribution has been received by Licensor and
++   subsequently incorporated within the Work.
++
++2. Grant of Copyright License. Subject to the terms and conditions of
++   this License, each Contributor hereby grants to You a perpetual,
++   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
++   copyright license to reproduce, prepare Derivative Works of,
++   publicly display, publicly perform, sublicense, and distribute the
++   Work and such Derivative Works in Source or Object form.
++
++3. Grant of Patent License. Subject to the terms and conditions of
++   this License, each Contributor hereby grants to You a perpetual,
++   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
++   (except as stated in this section) patent license to make, have made,
++   use, offer to sell, sell, import, and otherwise transfer the Work,
++   where such license applies only to those patent claims licensable
++   by such Contributor that are necessarily infringed by their
++   Contribution(s) alone or by combination of their Contribution(s)
++   with the Work to which such Contribution(s) was submitted. If You
++   institute patent litigation against any entity (including a
++   cross-claim or counterclaim in a lawsuit) alleging that the Work
++   or a Contribution incorporated within the Work constitutes direct
++   or contributory patent infringement, then any patent licenses
++   granted to You under this License for that Work shall terminate
++   as of the date such litigation is filed.
++
++4. Redistribution. You may reproduce and distribute copies of the
++   Work or Derivative Works thereof in any medium, with or without
++   modifications, and in Source or Object form, provided that You
++   meet the following conditions:
++
++   (a) You must give any other recipients of the Work or
++       Derivative Works a copy of this License; and
++
++   (b) You must cause any modified files to carry prominent notices
++       stating that You changed the files; and
++
++   (c) You must retain, in the Source form of any Derivative Works
++       that You distribute, all copyright, patent, trademark, and
++       attribution notices from the Source form of the Work,
++       excluding those notices that do not pertain to any part of
++       the Derivative Works; and
++
++   (d) If the Work includes a "NOTICE" text file as part of its
++       distribution, then any Derivative Works that You distribute must
++       include a readable copy of the attribution notices contained
++       within such NOTICE file, excluding those notices that do not
++       pertain to any part of the Derivative Works, in at least one
++       of the following places: within a NOTICE text file distributed
++       as part of the Derivative Works; within the Source form or
++       documentation, if provided along with the Derivative Works; or,
++       within a display generated by the Derivative Works, if and
++       wherever such third-party notices normally appear. The contents
++       of the NOTICE file are for informational purposes only and
++       do not modify the License. You may add Your own attribution
++       notices within Derivative Works that You distribute, alongside
++       or as an addendum to the NOTICE text from the Work, provided
++       that such additional attribution notices cannot be construed
++       as modifying the License.
++
++   You may add Your own copyright statement to Your modifications and
++   may provide additional or different license terms and conditions
++   for use, reproduction, or distribution of Your modifications, or
++   for any such Derivative Works as a whole, provided Your use,
++   reproduction, and distribution of the Work otherwise complies with
++   the conditions stated in this License.
++
++5. Submission of Contributions. Unless You explicitly state otherwise,
++   any Contribution intentionally submitted for inclusion in the Work
++   by You to the Licensor shall be under the terms and conditions of
++   this License, without any additional terms or conditions.
++   Notwithstanding the above, nothing herein shall supersede or modify
++   the terms of any separate license agreement you may have executed
++   with Licensor regarding such Contributions.
++
++6. Trademarks. This License does not grant permission to use the trade
++   names, trademarks, service marks, or product names of the Licensor,
++   except as required for reasonable and customary use in describing the
++   origin of the Work and reproducing the content of the NOTICE file.
++
++7. Disclaimer of Warranty. Unless required by applicable law or
++   agreed to in writing, Licensor provides the Work (and each
++   Contributor provides its Contributions) on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
++   implied, including, without limitation, any warranties or conditions
++   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
++   PARTICULAR PURPOSE. You are solely responsible for determining the
++   appropriateness of using or redistributing the Work and assume any
++   risks associated with Your exercise of permissions under this License.
++
++8. Limitation of Liability. In no event and under no legal theory,
++   whether in tort (including negligence), contract, or otherwise,
++   unless required by applicable law (such as deliberate and grossly
++   negligent acts) or agreed to in writing, shall any Contributor be
++   liable to You for damages, including any direct, indirect, special,
++   incidental, or consequential damages of any character arising as a
++   result of this License or out of the use or inability to use the
++   Work (including but not limited to damages for loss of goodwill,
++   work stoppage, computer failure or malfunction, or any and all
++   other commercial damages or losses), even if such Contributor
++   has been advised of the possibility of such damages.
++
++9. Accepting Warranty or Additional Liability. While redistributing
++   the Work or Derivative Works thereof, You may choose to offer,
++   and charge a fee for, acceptance of support, warranty, indemnity,
++   or other liability obligations and/or rights consistent with this
++   License. However, in accepting such obligations, You may act only
++   on Your own behalf and on Your sole responsibility, not on behalf
++   of any other Contributor, and only if You agree to indemnify,
++   defend, and hold each Contributor harmless for any liability
++   incurred by, or claims asserted against, such Contributor by reason
++   of your accepting any such warranty or additional liability.
++
++END OF TERMS AND CONDITIONS
++
++APPENDIX: How to apply the Apache License to your work.
++
++   To apply the Apache License to your work, attach the following
++   boilerplate notice, with the fields enclosed by brackets "[]"
++   replaced with your own identifying information. (Don't include
++   the brackets!)  The text should be enclosed in the appropriate
++   comment syntax for the file format. We also recommend that a
++   file or class name and description of purpose be included on the
++   same "printed page" as the copyright notice for easier
++   identification within third-party archives.
++
++Copyright [yyyy] [name of copyright owner]
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++	http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
+diff --git a/third_party/rust/any_all_workaround/LICENSE-MIT b/third_party/rust/any_all_workaround/LICENSE-MIT
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/any_all_workaround/LICENSE-MIT
+@@ -0,0 +1,25 @@
++Copyright (c) 2014 The Rust Project Developers
++
++Permission is hereby granted, free of charge, to any
++person obtaining a copy of this software and associated
++documentation files (the "Software"), to deal in the
++Software without restriction, including without
++limitation the rights to use, copy, modify, merge,
++publish, distribute, sublicense, and/or sell copies of
++the Software, and to permit persons to whom the Software
++is furnished to do so, subject to the following
++conditions:
++
++The above copyright notice and this permission notice
++shall be included in all copies or substantial portions
++of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
++ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
++TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
++PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
++SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
++OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
++IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++DEALINGS IN THE SOFTWARE.
 diff --git a/third_party/rust/any_all_workaround/LICENSE-MIT-QCMS b/third_party/rust/any_all_workaround/LICENSE-MIT-QCMS
 new file mode 100644
-index 0000000..eec8246
 --- /dev/null
 +++ b/third_party/rust/any_all_workaround/LICENSE-MIT-QCMS
 @@ -0,0 +1,21 @@
@@ -183,7 +473,6 @@ index 0000000..eec8246
 +WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 diff --git a/third_party/rust/any_all_workaround/README.md b/third_party/rust/any_all_workaround/README.md
 new file mode 100644
-index 0000000..9f83ac3
 --- /dev/null
 +++ b/third_party/rust/any_all_workaround/README.md
 @@ -0,0 +1,13 @@
@@ -202,7 +491,6 @@ index 0000000..9f83ac3
 +`MIT OR Apache-2.0`, since that's how `packed_simd` is licensed. (The ARM intrinsics Rust version workaround is from qcms, see LICENSE-MIT-QCMS.)
 diff --git a/third_party/rust/any_all_workaround/build.rs b/third_party/rust/any_all_workaround/build.rs
 new file mode 100644
-index 0000000..6810a88
 --- /dev/null
 +++ b/third_party/rust/any_all_workaround/build.rs
 @@ -0,0 +1,7 @@
@@ -215,7 +503,6 @@ index 0000000..6810a88
 +}
 diff --git a/third_party/rust/any_all_workaround/src/lib.rs b/third_party/rust/any_all_workaround/src/lib.rs
 new file mode 100644
-index 0000000..f0b8b13
 --- /dev/null
 +++ b/third_party/rust/any_all_workaround/src/lib.rs
 @@ -0,0 +1,110 @@
@@ -330,19 +617,22 @@ index 0000000..f0b8b13
 +    vpmax_u32
 +);
 diff --git a/third_party/rust/encoding_rs/.cargo-checksum.json b/third_party/rust/encoding_rs/.cargo-checksum.json
-index a5e1f1b..d5e91dd 100644
 --- a/third_party/rust/encoding_rs/.cargo-checksum.json
 +++ b/third_party/rust/encoding_rs/.cargo-checksum.json
-@@ -1 +1 @@
+@@ -1,1 +1,1 @@
 -{"files":{"CONTRIBUTING.md":"ca1901f3e8532fb4cec894fd3664f0eaa898c0c4b961d1b992d1ed54eacf362a","COPYRIGHT":"11789f45bb180841cd362a5eee6789c68ddb573a11105e30768c308a6add0190","Cargo.toml":"42fa83322aa9fd6723b77d35d0cacb92cbb6e7f573ce11c55f5225292866f8f4","Ideas.md":"b7452893f500163868d8de52c09addaf91e1632454ed02e892c467ed7ec39dbd","LICENSE-APACHE":"cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","LICENSE-MIT":"3fa4ca83dcc9237839b1bdeb2e6d16bdfb5ec0c5ce42b24694d8bbf0dcbef72c","LICENSE-WHATWG":"838118388fe5c2e7f1dbbaeed13e1c7f3ebf88be91319c7c1d77c18e987d1a50","README.md":"d938e8ab0b9ab67e74a1a4f48f23fdce956d0ad3a3f6147ae7612a92763c88d5","ci/miri.sh":"43cb8d82f49e3bfe2d2274b6ccd6f0714a4188ccef0cecc040829883cfdbee25","doc/Big5.txt":"f73a2edc5cb6c2d140ba6e07f4542e1c4a234950378acde1df93480f0ca0be0b","doc/EUC-JP.txt":"ee2818b907d0137f40a9ab9fd525fc700a44dbdddb6cf0c157a656566bae4bf1","doc/EUC-KR.txt":"71d9e2ccf3b124e8bdfb433c8cf2773fd878077038d0cec3c7237a50f4a78a30","doc/GBK.txt":"c1b522b5a799884e5001da661f42c5a8f4d0acb9ef1d74b206f22b5f65365606","doc/IBM866.txt":"a5a433e804d0f83af785015179fbc1d9b0eaf1f7960efcd04093e136b51fbd0e","doc/ISO-2022-JP.txt":"af86684f5a8f0e2868d7b2c292860140c3d2e5527530ca091f1b28198e8e2fe6","doc/ISO-8859-10.txt":"6d3949ad7c81ca176895101ed81a1db7df1060d64e262880b94bd31bb344ab4d","doc/ISO-8859-13.txt":"3951dd89cf93f7729148091683cf8511f4529388b7dc8dcd0d62eaed55be93fa","doc/ISO-8859-14.txt":"3d330784a0374fd255a38b47949675cc7168c800530534b0a01cac6edc623adc","doc/ISO-8859-15.txt":"24b1084aab5127a85aab99153f86e24694d0a3615f53b5ce23683f97cf66c47a","doc/ISO-8859-16.txt":"ce0272559b92ba76d7a7e476f6424ae4a5cc72e75b183611b08392e44add4d25","doc/ISO-8859-2.txt":"18ceff88c13d1b5ba455a3919b1e3de489045c4c3d2dd7e8527c125c75d54aad","doc/ISO-8859-3.txt":"21798404c68f4f5db59223362f24999da96968c0628427321fccce7d2849a130","doc/ISO-8859-4.txt":"d27f6520c6c5bfbcc19176b71d081cdb3bccde1622bb3e420d5680e812632d53","doc/ISO-8859-5.txt":"a10ec8d6ea7a78ad15da7275f6cb1a3365118527e28f9af6d0d5830501303f3a","doc/ISO-8859-6.txt":"ccda8a2efc96115336bdd77776637b9712425e44fbcf745353b9057fbef144e7","doc/ISO-8859-7.txt":"17900fa1f27a445958f0a77d7d9056be375a6bd7ee4492aa680c7c1500bab85e","doc/ISO-8859-8-I.txt":"8357555646d54265a9b9ffa3e68b08d132312f1561c60108ff9b8b1167b6ecf2","doc/ISO-8859-8.txt":"72cd6f3afb7b4a9c16a66a362473315770b7755d72c86c870e52fc3eba86c8af","doc/KOI8-R.txt":"839cf19a38da994488004ed7814b1f6151640156a9a2af02bf2efca745fb5966","doc/KOI8-U.txt":"0cc76624ed1f024183e2298b7e019957da2c70c8ca06e0fc4e6f353f50a5054f","doc/Shift_JIS.txt":"34c49141818cb9ddbcf59cc858f78a79be8ad148d563f26415108ae1f148443f","doc/UTF-16BE.txt":"e2e280d8acbaa6d2a6b3569d60e17500a285f2baa0df3363dd85537cd5a1ef8f","doc/UTF-16LE.txt":"70bdc170e3fc5298ba68f10125fb5eeb8b077036cc96bb4416c4de396f6d76c1","doc/UTF-8.txt":"ea7bae742e613010ced002cf4b601a737d2203fad65e115611451bc4428f548a","doc/gb18030.txt":"dc71378a8f07a2d8659f69ee81fb8791fef56ba86f124b429978285237bb4a7b","doc/macintosh.txt":"57491e53866711b4672d9b9ff35380b9dac9e0d8e3d6c20bdd6140603687c023","doc/replacement.txt":"4b6c3bbd7999d9d4108a281594bd02d13607e334a95465afff8c2c08d395f0e4","doc/windows-1250.txt":"61296bb6a21cdab602300d32ecfba434cb82de5ac3bc88d58710d2f125e28d39","doc/windows-1251.txt":"7deea1c61dea1485c8ff02db2c7d578db7a9aab63ab1cfd02ec04b515864689e","doc/windows-1252.txt":"933ef3bdddfce5ee132b9f1a1aa8b47423d2587bbe475b19028d0a6d38e180b6","doc/windows-1253.txt":"1a38748b88e99071a5c7b3d5456ead4caedeabab50d50d658be105bc113714de","doc/windows-1254.txt":"f8372f86c6f8d642563cd6ddc025260553292a39423df1683a98670bd7bf2b47","doc/windows-1255.txt":"4e5852494730054e2da258a74e1b9d780abbcdd8ce22ebc218ca2efe9e90493d","doc/windows-1256.txt":"c0879c5172abedead302a406e8f60d9cd9598694a0ffa4fd288ffe4fef7b8ea1","doc/windows-1257.txt":"c28a0c9f964fcb2b46d21f537c402446501a2800670481d6abf9fd9e9018d523","doc/windows-1258.txt":"5019ae4d61805c79aacbf17c93793342dbb098d65a1837783bc3e2c6d6a23602","doc/windows-874.txt":"4ef0e4501c5feba8b17aee1818602ed44b36ca8475db771ce2fc16d392cabecc","doc/x-mac-cyrillic.txt":"58be154d8a888ca3d484b83b44f749823ef339ab27f14d90ca9a856f5050a8bd","doc/x-user-defined.txt":"f9cd07c4321bf5cfb0be4bdddd251072999b04a6cf7a6f5bc63709a84e2c1ffc","generate-encoding-data.py":"be989dd25c6b946e3e8745fdc8e8a80fcf24b3be99ad0b4b78153ba3f6ab6310","rustfmt.toml":"85c1a3b4382fd89e991cbb81b70fb52780472edc064c963943cdaaa56e0a2030","src/ascii.rs":"c44c002641adb5ebc4368707a8cc0a076d2f33e6a5c27b1b69988eb515f5653d","src/big5.rs":"ec6e2913011a38e9a3e825a1731f139a7ca1d5b264fefae51a3cc1a68a57cef9","src/data.rs":"8a617cc57032092d65850eb27e00de687c80aea3299e839a1f58b42d0b35abf3","src/euc_jp.rs":"32047f5b540188c4cb19c07165f846b9786a09f18e315ed3e9bda1293dae52aa","src/euc_kr.rs":"9b25afc72d9378700eecfac58d55ad1c5946d6cd0ccde2c29c08200ef2de6bb9","src/gb18030.rs":"808587168d73f0c80f8520f0ca9b161866ed2efeb17a05e85fdf3b8efe7ba28a","src/handles.rs":"cc83dc0754751d67f5688a65c5e0191cba02f6bacce81a0813a243cba55eef7a","src/iso_2022_jp.rs":"9bb485e82574f4b7d4b2364f0ff276acb6a0bc111758420a3b0ec5e04c196652","src/lib.rs":"1dc07b818e45846b16ddcaf0de46c8862dd7df8099123ec38b95c3f8ad9c91ec","src/macros.rs":"200997f8870de8bfd8cdc475e92115df42108c0df661e49d3d1cbc32056e1d99","src/mem.rs":"0bf34103e0ad1b842a13a082dee2b920b05cf4fb0f145c9ee7f608f4cb4a544f","src/replacement.rs":"7660b34a53f8c1ca2bdfa0e51e843ec28326950952ad8bc96569feb93ac62308","src/shift_jis.rs":"6951ae67e36b1a12fa3a30734957f444d8b1b4ae0e2bde52060b29bd0f16d9d9","src/simd_funcs.rs":"2612aba86e1d201096d7e47a859bc3444f85934cc82d8adc6d39a4304d9eecfc","src/single_byte.rs":"3c9e9c1f946ae622c725ba9421240c1faa9a05e95fa10dd4642a25cb276a1edc","src/test_data/big5_in.txt":"4c5a8691f8dc717311889c63894026d2fb62725a86c4208ca274a9cc8d42a503","src/test_data/big5_in_ref.txt":"99d399e17750cf9c7cf30bb253dbfe35b81c4fcbdead93cfa48b1429213473c7","src/test_data/big5_out.txt":"6193ca97c297aa20e09396038d18e938bb7ea331c26f0f2454097296723a0b13","src/test_data/big5_out_ref.txt":"36567691f557df144f6cc520015a87038dfa156f296fcf103b56ae9a718be1fc","src/test_data/euc_kr_in.txt":"c86a7224f3215fa0d04e685622a752fdc72763e8ae076230c7fd62de57ec4074","src/test_data/euc_kr_in_ref.txt":"1f419f4ca47d708b54c73c461545a022ae2e20498fdbf8005a483d752a204883","src/test_data/euc_kr_out.txt":"e7f32e026f70be1e1b58e0047baf7d3d2c520269c4f9b9992e158b4decb0a1a3","src/test_data/euc_kr_out_ref.txt":"c9907857980b20b8e9e3b584482ed6567a2be6185d72237b6322f0404944924e","src/test_data/gb18030_in.txt":"ab7231b2d3e9afacdbd7d7f3b9e5361a7ff9f7e1cfdb4f3bd905b9362b309e53","src/test_data/gb18030_in_ref.txt":"dc5069421adca2043c55f5012b55a76fdff651d22e6e699fd0978f8d5706815c","src/test_data/gb18030_out.txt":"f0208d527f5ca63de7d9a0323be8d5cf12d8a104b2943d92c2701f0c3364dac1","src/test_data/gb18030_out_ref.txt":"6819fe47627e4ea01027003fc514b9f21a1322e732d7f1fb92cc6c5455bc6c07","src/test_data/iso_2022_jp_in.txt":"cd24bbdcb1834e25db54646fbf4c41560a13dc7540f6be3dba4f5d97d44513af","src/test_data/iso_2022_jp_in_ref.txt":"3dc4e6a5e06471942d086b16c9440945e78415f6f3f47e43717e4bc2eac2cdf5","src/test_data/iso_2022_jp_out.txt":"9b6f015329dda6c3f9ee5ce6dbd6fa9c89acc21283e886836c78b8d833480c21","src/test_data/iso_2022_jp_out_ref.txt":"78cb260093a20116ad9a42f43b05d1848c5ab100b6b9a850749809e943884b35","src/test_data/jis0208_in.txt":"6df3030553ffb0a6615bb33dc8ea9dca6d9623a9028e2ffec754ce3c3da824cc","src/test_data/jis0208_in_ref.txt":"3dc4e6a5e06471942d086b16c9440945e78415f6f3f47e43717e4bc2eac2cdf5","src/test_data/jis0208_out.txt":"4ec24477e1675ce750733bdc3c5add1cd27b6bd4ce1f09289564646e9654e857","src/test_data/jis0208_out_ref.txt":"c3e1cef5032b2b1d93a406f31ff940c4e2dfe8859b8b17ca2761fee7a75a0e48","src/test_data/jis0212_in.txt":"c011f0dd72bd7c8cd922df9374ef8d2769a77190514c77f6c62b415852eeb9fe","src/test_data/jis0212_in_ref.txt":"7d9458b3d2f73e7092a7f505c08ce1d233dde18aa679fbcf9889256239cc9e06","src/test_data/shift_jis_in.txt":"02e389ccef0dd2122e63f503899402cb7f797912c2444cc80ab93131116c5524","src/test_data/shift_jis_in_ref.txt":"512f985950ca902e643c88682dba9708b7c38d3c5ec2925168ab00ac94ab19f9","src/test_data/shift_jis_out.txt":"5fbc44da7bf639bf6cfe0fa1fd3eba7102b88f81919c9ea991302712f69426fb","src/test_data/shift_jis_out_ref.txt":"466322c6fed8286c64582731755290c2296508efdd258826e6279686649b481f","src/test_labels_names.rs":"23a2e11b02b3b8d15fb5613a625e3edb2c61e70e3c581abfd638719a4088200d","src/testing.rs":"f59e671e95a98a56f6b573e8c6be4d71e670bf52f7e20eb1605d990aafa1894e","src/utf_16.rs":"c071a147fad38d750c2c247e141b76b929a48007b99f26b2922b9caecdaf2f25","src/utf_8.rs":"7b7d887b347f1aefa03246b028a36a72758a4ce76c28f3b45c19467851aa7839","src/variant.rs":"1fab5363588a1554a7169de8731ea9cded7ac63ea35caabdd1c27a8dde68c27b","src/x_user_defined.rs":"c9c010730dfb9f141d4fed19350c08a21af240913a54bb64f5ca89ff93b6b7d1"},"package":"7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"}
 \ No newline at end of file
 +{"files":{"CONTRIBUTING.md":"ca1901f3e8532fb4cec894fd3664f0eaa898c0c4b961d1b992d1ed54eacf362a","COPYRIGHT":"11789f45bb180841cd362a5eee6789c68ddb573a11105e30768c308a6add0190","Cargo.toml":"22a4d210c92dae9f32c6944ef340ee8fdd027f99c081577e8907123e2a93383e","Ideas.md":"b7452893f500163868d8de52c09addaf91e1632454ed02e892c467ed7ec39dbd","LICENSE-APACHE":"cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","LICENSE-MIT":"3fa4ca83dcc9237839b1bdeb2e6d16bdfb5ec0c5ce42b24694d8bbf0dcbef72c","LICENSE-WHATWG":"838118388fe5c2e7f1dbbaeed13e1c7f3ebf88be91319c7c1d77c18e987d1a50","README.md":"1d08aefcb92afa81b18154049c9abbcad4540a23f7172e9f9bbed5af33f1a087","ci/miri.sh":"43cb8d82f49e3bfe2d2274b6ccd6f0714a4188ccef0cecc040829883cfdbee25","doc/Big5.txt":"f73a2edc5cb6c2d140ba6e07f4542e1c4a234950378acde1df93480f0ca0be0b","doc/EUC-JP.txt":"ee2818b907d0137f40a9ab9fd525fc700a44dbdddb6cf0c157a656566bae4bf1","doc/EUC-KR.txt":"71d9e2ccf3b124e8bdfb433c8cf2773fd878077038d0cec3c7237a50f4a78a30","doc/GBK.txt":"c1b522b5a799884e5001da661f42c5a8f4d0acb9ef1d74b206f22b5f65365606","doc/IBM866.txt":"a5a433e804d0f83af785015179fbc1d9b0eaf1f7960efcd04093e136b51fbd0e","doc/ISO-2022-JP.txt":"af86684f5a8f0e2868d7b2c292860140c3d2e5527530ca091f1b28198e8e2fe6","doc/ISO-8859-10.txt":"6d3949ad7c81ca176895101ed81a1db7df1060d64e262880b94bd31bb344ab4d","doc/ISO-8859-13.txt":"3951dd89cf93f7729148091683cf8511f4529388b7dc8dcd0d62eaed55be93fa","doc/ISO-8859-14.txt":"3d330784a0374fd255a38b47949675cc7168c800530534b0a01cac6edc623adc","doc/ISO-8859-15.txt":"24b1084aab5127a85aab99153f86e24694d0a3615f53b5ce23683f97cf66c47a","doc/ISO-8859-16.txt":"ce0272559b92ba76d7a7e476f6424ae4a5cc72e75b183611b08392e44add4d25","doc/ISO-8859-2.txt":"18ceff88c13d1b5ba455a3919b1e3de489045c4c3d2dd7e8527c125c75d54aad","doc/ISO-8859-3.txt":"21798404c68f4f5db59223362f24999da96968c0628427321fccce7d2849a130","doc/ISO-8859-4.txt":"d27f6520c6c5bfbcc19176b71d081cdb3bccde1622bb3e420d5680e812632d53","doc/ISO-8859-5.txt":"a10ec8d6ea7a78ad15da7275f6cb1a3365118527e28f9af6d0d5830501303f3a","doc/ISO-8859-6.txt":"ccda8a2efc96115336bdd77776637b9712425e44fbcf745353b9057fbef144e7","doc/ISO-8859-7.txt":"17900fa1f27a445958f0a77d7d9056be375a6bd7ee4492aa680c7c1500bab85e","doc/ISO-8859-8-I.txt":"8357555646d54265a9b9ffa3e68b08d132312f1561c60108ff9b8b1167b6ecf2","doc/ISO-8859-8.txt":"72cd6f3afb7b4a9c16a66a362473315770b7755d72c86c870e52fc3eba86c8af","doc/KOI8-R.txt":"839cf19a38da994488004ed7814b1f6151640156a9a2af02bf2efca745fb5966","doc/KOI8-U.txt":"0cc76624ed1f024183e2298b7e019957da2c70c8ca06e0fc4e6f353f50a5054f","doc/Shift_JIS.txt":"34c49141818cb9ddbcf59cc858f78a79be8ad148d563f26415108ae1f148443f","doc/UTF-16BE.txt":"e2e280d8acbaa6d2a6b3569d60e17500a285f2baa0df3363dd85537cd5a1ef8f","doc/UTF-16LE.txt":"70bdc170e3fc5298ba68f10125fb5eeb8b077036cc96bb4416c4de396f6d76c1","doc/UTF-8.txt":"ea7bae742e613010ced002cf4b601a737d2203fad65e115611451bc4428f548a","doc/gb18030.txt":"dc71378a8f07a2d8659f69ee81fb8791fef56ba86f124b429978285237bb4a7b","doc/macintosh.txt":"57491e53866711b4672d9b9ff35380b9dac9e0d8e3d6c20bdd6140603687c023","doc/replacement.txt":"4b6c3bbd7999d9d4108a281594bd02d13607e334a95465afff8c2c08d395f0e4","doc/windows-1250.txt":"61296bb6a21cdab602300d32ecfba434cb82de5ac3bc88d58710d2f125e28d39","doc/windows-1251.txt":"7deea1c61dea1485c8ff02db2c7d578db7a9aab63ab1cfd02ec04b515864689e","doc/windows-1252.txt":"933ef3bdddfce5ee132b9f1a1aa8b47423d2587bbe475b19028d0a6d38e180b6","doc/windows-1253.txt":"1a38748b88e99071a5c7b3d5456ead4caedeabab50d50d658be105bc113714de","doc/windows-1254.txt":"f8372f86c6f8d642563cd6ddc025260553292a39423df1683a98670bd7bf2b47","doc/windows-1255.txt":"4e5852494730054e2da258a74e1b9d780abbcdd8ce22ebc218ca2efe9e90493d","doc/windows-1256.txt":"c0879c5172abedead302a406e8f60d9cd9598694a0ffa4fd288ffe4fef7b8ea1","doc/windows-1257.txt":"c28a0c9f964fcb2b46d21f537c402446501a2800670481d6abf9fd9e9018d523","doc/windows-1258.txt":"5019ae4d61805c79aacbf17c93793342dbb098d65a1837783bc3e2c6d6a23602","doc/windows-874.txt":"4ef0e4501c5feba8b17aee1818602ed44b36ca8475db771ce2fc16d392cabecc","doc/x-mac-cyrillic.txt":"58be154d8a888ca3d484b83b44f749823ef339ab27f14d90ca9a856f5050a8bd","doc/x-user-defined.txt":"f9cd07c4321bf5cfb0be4bdddd251072999b04a6cf7a6f5bc63709a84e2c1ffc","generate-encoding-data.py":"be989dd25c6b946e3e8745fdc8e8a80fcf24b3be99ad0b4b78153ba3f6ab6310","rustfmt.toml":"85c1a3b4382fd89e991cbb81b70fb52780472edc064c963943cdaaa56e0a2030","src/ascii.rs":"588e38b01e666d5e7462617ea7e90a108d608dec9e016f3d273ac0744af2e05d","src/big5.rs":"ec6e2913011a38e9a3e825a1731f139a7ca1d5b264fefae51a3cc1a68a57cef9","src/data.rs":"8a617cc57032092d65850eb27e00de687c80aea3299e839a1f58b42d0b35abf3","src/euc_jp.rs":"32047f5b540188c4cb19c07165f846b9786a09f18e315ed3e9bda1293dae52aa","src/euc_kr.rs":"9b25afc72d9378700eecfac58d55ad1c5946d6cd0ccde2c29c08200ef2de6bb9","src/gb18030.rs":"808587168d73f0c80f8520f0ca9b161866ed2efeb17a05e85fdf3b8efe7ba28a","src/handles.rs":"b08cef1f5785bb6a4822f2e844c6df1b046b737b7a075e4593eaa8c4208e9fe2","src/iso_2022_jp.rs":"9bb485e82574f4b7d4b2364f0ff276acb6a0bc111758420a3b0ec5e04c196652","src/lib.rs":"834f44b670ec48ee82c0e12223d1567313fdd9f88bca5f4b117c82c1828f559f","src/macros.rs":"200997f8870de8bfd8cdc475e92115df42108c0df661e49d3d1cbc32056e1d99","src/mem.rs":"948571137d3b151df8db4fb2c733e74ae595d055cdf0ad83abcab9341d6adabe","src/replacement.rs":"7660b34a53f8c1ca2bdfa0e51e843ec28326950952ad8bc96569feb93ac62308","src/shift_jis.rs":"6951ae67e36b1a12fa3a30734957f444d8b1b4ae0e2bde52060b29bd0f16d9d9","src/simd_funcs.rs":"05c6e77af74bfe73cd39a752067c11425d6b46e5da419910f54bf75a5c02a984","src/single_byte.rs":"3ad87116fb339434a4b58e8f2b15485f2b66b9f7814d708f16194ed08f6d6ccf","src/test_data/big5_in.txt":"4c5a8691f8dc717311889c63894026d2fb62725a86c4208ca274a9cc8d42a503","src/test_data/big5_in_ref.txt":"99d399e17750cf9c7cf30bb253dbfe35b81c4fcbdead93cfa48b1429213473c7","src/test_data/big5_out.txt":"6193ca97c297aa20e09396038d18e938bb7ea331c26f0f2454097296723a0b13","src/test_data/big5_out_ref.txt":"36567691f557df144f6cc520015a87038dfa156f296fcf103b56ae9a718be1fc","src/test_data/euc_kr_in.txt":"c86a7224f3215fa0d04e685622a752fdc72763e8ae076230c7fd62de57ec4074","src/test_data/euc_kr_in_ref.txt":"1f419f4ca47d708b54c73c461545a022ae2e20498fdbf8005a483d752a204883","src/test_data/euc_kr_out.txt":"e7f32e026f70be1e1b58e0047baf7d3d2c520269c4f9b9992e158b4decb0a1a3","src/test_data/euc_kr_out_ref.txt":"c9907857980b20b8e9e3b584482ed6567a2be6185d72237b6322f0404944924e","src/test_data/gb18030_in.txt":"ab7231b2d3e9afacdbd7d7f3b9e5361a7ff9f7e1cfdb4f3bd905b9362b309e53","src/test_data/gb18030_in_ref.txt":"dc5069421adca2043c55f5012b55a76fdff651d22e6e699fd0978f8d5706815c","src/test_data/gb18030_out.txt":"f0208d527f5ca63de7d9a0323be8d5cf12d8a104b2943d92c2701f0c3364dac1","src/test_data/gb18030_out_ref.txt":"6819fe47627e4ea01027003fc514b9f21a1322e732d7f1fb92cc6c5455bc6c07","src/test_data/iso_2022_jp_in.txt":"cd24bbdcb1834e25db54646fbf4c41560a13dc7540f6be3dba4f5d97d44513af","src/test_data/iso_2022_jp_in_ref.txt":"3dc4e6a5e06471942d086b16c9440945e78415f6f3f47e43717e4bc2eac2cdf5","src/test_data/iso_2022_jp_out.txt":"9b6f015329dda6c3f9ee5ce6dbd6fa9c89acc21283e886836c78b8d833480c21","src/test_data/iso_2022_jp_out_ref.txt":"78cb260093a20116ad9a42f43b05d1848c5ab100b6b9a850749809e943884b35","src/test_data/jis0208_in.txt":"6df3030553ffb0a6615bb33dc8ea9dca6d9623a9028e2ffec754ce3c3da824cc","src/test_data/jis0208_in_ref.txt":"3dc4e6a5e06471942d086b16c9440945e78415f6f3f47e43717e4bc2eac2cdf5","src/test_data/jis0208_out.txt":"4ec24477e1675ce750733bdc3c5add1cd27b6bd4ce1f09289564646e9654e857","src/test_data/jis0208_out_ref.txt":"c3e1cef5032b2b1d93a406f31ff940c4e2dfe8859b8b17ca2761fee7a75a0e48","src/test_data/jis0212_in.txt":"c011f0dd72bd7c8cd922df9374ef8d2769a77190514c77f6c62b415852eeb9fe","src/test_data/jis0212_in_ref.txt":"7d9458b3d2f73e7092a7f505c08ce1d233dde18aa679fbcf9889256239cc9e06","src/test_data/shift_jis_in.txt":"02e389ccef0dd2122e63f503899402cb7f797912c2444cc80ab93131116c5524","src/test_data/shift_jis_in_ref.txt":"512f985950ca902e643c88682dba9708b7c38d3c5ec2925168ab00ac94ab19f9","src/test_data/shift_jis_out.txt":"5fbc44da7bf639bf6cfe0fa1fd3eba7102b88f81919c9ea991302712f69426fb","src/test_data/shift_jis_out_ref.txt":"466322c6fed8286c64582731755290c2296508efdd258826e6279686649b481f","src/test_labels_names.rs":"23a2e11b02b3b8d15fb5613a625e3edb2c61e70e3c581abfd638719a4088200d","src/testing.rs":"f59e671e95a98a56f6b573e8c6be4d71e670bf52f7e20eb1605d990aafa1894e","src/utf_16.rs":"c071a147fad38d750c2c247e141b76b929a48007b99f26b2922b9caecdaf2f25","src/utf_8.rs":"7b7d887b347f1aefa03246b028a36a72758a4ce76c28f3b45c19467851aa7839","src/variant.rs":"1fab5363588a1554a7169de8731ea9cded7ac63ea35caabdd1c27a8dde68c27b","src/x_user_defined.rs":"9456ca46168ef86c98399a2536f577ef7be3cdde90c0c51392d8ac48519d3fae"},"package":"b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"}
 \ No newline at end of file
 diff --git a/third_party/rust/encoding_rs/Cargo.toml b/third_party/rust/encoding_rs/Cargo.toml
-index e9fd6c0..08bb611 100644
 --- a/third_party/rust/encoding_rs/Cargo.toml
 +++ b/third_party/rust/encoding_rs/Cargo.toml
-@@ -11,8 +11,9 @@
+@@ -6,18 +6,19 @@
+ # to registry (e.g., crates.io) dependencies.
+ #
+ # If you are reading this file be aware that the original Cargo.toml
+ # will likely look very different (and much more reasonable).
+ # See Cargo.toml.orig for the original contents.
  
  [package]
  edition = "2018"
@@ -353,7 +643,17 @@ index e9fd6c0..08bb611 100644
  authors = ["Henri Sivonen <hsivonen@hsivonen.fi>"]
  description = "A Gecko-oriented implementation of the Encoding Standard"
  homepage = "https://docs.rs/encoding_rs/"
-@@ -36,13 +37,13 @@ repository = "https://github.com/hsivonen/encoding_rs"
+ documentation = "https://docs.rs/encoding_rs/"
+ readme = "README.md"
+ keywords = [
+     "encoding",
+     "web",
+@@ -31,23 +32,23 @@ categories = [
+     "internationalization",
+ ]
+ license = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+ repository = "https://github.com/hsivonen/encoding_rs"
+ 
  [profile.release]
  lto = true
  
@@ -371,7 +671,17 @@ index e9fd6c0..08bb611 100644
  [dependencies.serde]
  version = "1.0"
  optional = true
-@@ -74,10 +75,4 @@ fast-legacy-encode = [
+ 
+ [dev-dependencies.bincode]
+ version = "1.0"
+ 
+ [dev-dependencies.serde_derive]
+@@ -69,15 +70,9 @@ fast-legacy-encode = [
+     "fast-hanja-encode",
+     "fast-kanji-encode",
+     "fast-gb-hanzi-encode",
+     "fast-big5-hanzi-encode",
+ ]
  less-slow-big5-hanzi-encode = []
  less-slow-gb-hanzi-encode = []
  less-slow-kanji-encode = []
@@ -384,10 +694,14 @@ index e9fd6c0..08bb611 100644
 -repository = "hsivonen/encoding_rs"
 +simd-accel = ["any_all_workaround"]
 diff --git a/third_party/rust/encoding_rs/README.md b/third_party/rust/encoding_rs/README.md
-index c0b596c..ed0e954 100644
 --- a/third_party/rust/encoding_rs/README.md
 +++ b/third_party/rust/encoding_rs/README.md
-@@ -167,13 +167,15 @@ There are currently these optional cargo features:
+@@ -162,50 +162,36 @@ wrappers.
+ * [C++](https://github.com/hsivonen/recode_cpp)
+ 
+ ## Optional features
+ 
+ There are currently these optional cargo features:
  
  ### `simd-accel`
  
@@ -405,7 +719,11 @@ index c0b596c..ed0e954 100644
  
  * x86_64
  * i686
-@@ -185,22 +187,6 @@ above, and you are prepared _to have to revise your configuration when updating
+ * aarch64
+ * thumbv7neon
+ 
+ If you use nightly Rust, you use targets whose first component is one of the
+ above, and you are prepared _to have to revise your configuration when updating
  Rust_, you should enable this feature. Otherwise, please _do not_ enable this
  feature.
  
@@ -428,7 +746,17 @@ index c0b596c..ed0e954 100644
  Used by Firefox.
  
  ### `serde`
-@@ -381,8 +367,9 @@ as semver-breaking, because this crate depends on `cfg-if`, which doesn't
+ 
+ Enables support for serializing and deserializing `&'static Encoding`-typed
+ struct fields using [Serde][1].
+ 
+ [1]: https://serde.rs/
+@@ -376,18 +362,19 @@ It is a goal to support the latest stabl
+ the version of Rust that's used for Firefox Nightly.
+ 
+ At this time, there is no firm commitment to support a version older than
+ what's required by Firefox, and there is no commitment to treat MSRV changes
+ as semver-breaking, because this crate depends on `cfg-if`, which doesn't
  appear to treat MSRV changes as semver-breaking, so it would be useless for
  this crate to treat MSRV changes as semver-breaking.
  
@@ -439,7 +767,17 @@ index c0b596c..ed0e954 100644
  
  ## Compatibility with rust-encoding
  
-@@ -446,10 +433,17 @@ To regenerate the generated code:
+ A compatibility layer that implements the rust-encoding API on top of
+ encoding_rs is
+ [provided as a separate crate](https://github.com/hsivonen/encoding_rs_compat)
+ (cannot be uploaded to crates.io). The compatibility layer was originally
+ written with the assuption that Firefox would need it, but it is not currently
+@@ -441,20 +428,27 @@ To regenerate the generated code:
+ - [x] Implement the rust-encoding API in terms of encoding_rs.
+ - [x] Add SIMD acceleration for Aarch64.
+ - [x] Investigate the use of NEON on 32-bit ARM.
+ - [ ] ~Investigate Björn Höhrmann's lookup table acceleration for UTF-8 as
+       adapted to Rust in rust-encoding.~
  - [x] Add actually fast CJK encode options.
  - [ ] ~Investigate [Bob Steagall's lookup table acceleration for UTF-8](https://github.com/BobSteagall/CppNow2018/blob/master/FastConversionFromUTF-8/Fast%20Conversion%20From%20UTF-8%20with%20C%2B%2B%2C%20DFAs%2C%20and%20SSE%20Intrinsics%20-%20Bob%20Steagall%20-%20C%2B%2BNow%202018.pdf).~
  - [x] Provide a build mode that works without `alloc` (with lesser API surface).
@@ -458,11 +796,20 @@ index c0b596c..ed0e954 100644
  ### 0.8.33
  
  * Use `packed_simd` instead of `packed_simd_2` again now that updates are back under the `packed_simd` name. Only affects the `simd-accel` optional nightly feature.
+ 
+ ### 0.8.32
+ 
+ * Removed `build.rs`. (This removal should resolve false positives reported by some antivirus products. This may break some build configurations that have opted out of Rust's guarantees against future build breakage.)
+ * Internal change to what API is used for reinterpreting the lane configuration of SIMD vectors.
 diff --git a/third_party/rust/encoding_rs/src/ascii.rs b/third_party/rust/encoding_rs/src/ascii.rs
-index 90644de..80233f2 100644
 --- a/third_party/rust/encoding_rs/src/ascii.rs
 +++ b/third_party/rust/encoding_rs/src/ascii.rs
-@@ -51,6 +51,8 @@ cfg_if! {
+@@ -46,71 +46,87 @@ cfg_if! {
+         #[allow(dead_code)]
+         #[inline(always)]
+         fn likely(b: bool) -> bool {
+             b
+         }
      }
  }
  
@@ -471,7 +818,11 @@ index 90644de..80233f2 100644
  // `as` truncates, so works on 32-bit, too.
  #[allow(dead_code)]
  pub const ASCII_MASK: usize = 0x8080_8080_8080_8080u64 as usize;
-@@ -62,6 +64,9 @@ pub const BASIC_LATIN_MASK: usize = 0xFF80_FF80_FF80_FF80u64 as usize;
+ 
+ // `as` truncates, so works on 32-bit, too.
+ #[allow(dead_code)]
+ pub const BASIC_LATIN_MASK: usize = 0xFF80_FF80_FF80_FF80u64 as usize;
+ 
  #[allow(unused_macros)]
  macro_rules! ascii_naive {
      ($name:ident, $src_unit:ty, $dst_unit:ty) => {
@@ -481,7 +832,9 @@ index 90644de..80233f2 100644
          #[inline(always)]
          pub unsafe fn $name(
              src: *const $src_unit,
-@@ -71,10 +76,13 @@ macro_rules! ascii_naive {
+             dst: *mut $dst_unit,
+             len: usize,
+         ) -> Option<($src_unit, usize)> {
              // Yes, manually omitting the bound check here matters
              // a lot for perf.
              for i in 0..len {
@@ -495,7 +848,10 @@ index 90644de..80233f2 100644
                  *(dst.add(i)) = code_unit as $dst_unit;
              }
              return None;
-@@ -85,9 +93,15 @@ macro_rules! ascii_naive {
+         }
+     };
+ }
+ 
  #[allow(unused_macros)]
  macro_rules! ascii_alu {
      ($name:ident,
@@ -511,7 +867,10 @@ index 90644de..80233f2 100644
          #[cfg_attr(feature = "cargo-clippy", allow(never_loop, cast_ptr_alignment))]
          #[inline(always)]
          pub unsafe fn $name(
-@@ -98,6 +112,7 @@ macro_rules! ascii_alu {
+             src: *const $src_unit,
+             dst: *mut $dst_unit,
+             len: usize,
+         ) -> Option<($src_unit, usize)> {
              let mut offset = 0usize;
              // This loop is only broken out of as a `goto` forward
              loop {
@@ -519,7 +878,8 @@ index 90644de..80233f2 100644
                  let mut until_alignment = {
                      // Check if the other unit aligns if we move the narrower unit
                      // to alignment.
-@@ -106,6 +121,7 @@ macro_rules! ascii_alu {
+                     //               if ::core::mem::size_of::<$src_unit>() == ::core::mem::size_of::<$dst_unit>() {
+                     // ascii_to_ascii
                      let src_alignment = (src as usize) & ALU_ALIGNMENT_MASK;
                      let dst_alignment = (dst as usize) & ALU_ALIGNMENT_MASK;
                      if src_alignment != dst_alignment {
@@ -527,7 +887,17 @@ index 90644de..80233f2 100644
                          break;
                      }
                      (ALU_ALIGNMENT - src_alignment) & ALU_ALIGNMENT_MASK
-@@ -134,25 +150,40 @@ macro_rules! ascii_alu {
+                     //               } else if ::core::mem::size_of::<$src_unit>() < ::core::mem::size_of::<$dst_unit>() {
+                     // ascii_to_basic_latin
+                     //                   let src_until_alignment = (ALIGNMENT - ((src as usize) & ALIGNMENT_MASK)) & ALIGNMENT_MASK;
+                     //                   if (dst.add(src_until_alignment) as usize) & ALIGNMENT_MASK != 0 {
+                     //                       break;
+@@ -129,74 +145,104 @@ macro_rules! ascii_alu {
+                     // Moving pointers to alignment seems to be a pessimization on
+                     // x86_64 for operations that have UTF-16 as the internal
+                     // Unicode representation. However, since it seems to be a win
+                     // on ARM (tested ARMv7 code running on ARMv8 [rpi3]), except
+                     // mixed results when encoding from UTF-16 and since x86 and
                      // x86_64 should be using SSE2 in due course, keeping the move
                      // to alignment here. It would be good to test on more ARM CPUs
                      // and on real MIPS and POWER hardware.
@@ -568,7 +938,7 @@ index 90644de..80233f2 100644
                          if offset > len_minus_stride {
                              break;
                          }
-@@ -160,11 +191,17 @@ macro_rules! ascii_alu {
+                     }
                  }
                  break;
              }
@@ -586,7 +956,11 @@ index 90644de..80233f2 100644
                  *(dst.add(offset)) = code_unit as $dst_unit;
                  offset += 1;
              }
-@@ -176,9 +213,16 @@ macro_rules! ascii_alu {
+             None
+         }
+     };
+ }
+ 
  #[allow(unused_macros)]
  macro_rules! basic_latin_alu {
      ($name:ident,
@@ -603,7 +977,13 @@ index 90644de..80233f2 100644
          #[cfg_attr(
              feature = "cargo-clippy",
              allow(never_loop, cast_ptr_alignment, cast_lossless)
-@@ -192,6 +236,8 @@ macro_rules! basic_latin_alu {
+         )]
+         #[inline(always)]
+         pub unsafe fn $name(
+             src: *const $src_unit,
+             dst: *mut $dst_unit,
+             len: usize,
+         ) -> Option<($src_unit, usize)> {
              let mut offset = 0usize;
              // This loop is only broken out of as a `goto` forward
              loop {
@@ -612,7 +992,17 @@ index 90644de..80233f2 100644
                  let mut until_alignment = {
                      // Check if the other unit aligns if we move the narrower unit
                      // to alignment.
-@@ -237,24 +283,37 @@ macro_rules! basic_latin_alu {
+                     //               if ::core::mem::size_of::<$src_unit>() == ::core::mem::size_of::<$dst_unit>() {
+                     // ascii_to_ascii
+                     //                   let src_alignment = (src as usize) & ALIGNMENT_MASK;
+                     //                   let dst_alignment = (dst as usize) & ALIGNMENT_MASK;
+                     //                   if src_alignment != dst_alignment {
+@@ -232,66 +278,89 @@ macro_rules! basic_latin_alu {
+                     // Moving pointers to alignment seems to be a pessimization on
+                     // x86_64 for operations that have UTF-16 as the internal
+                     // Unicode representation. However, since it seems to be a win
+                     // on ARM (tested ARMv7 code running on ARMv8 [rpi3]), except
+                     // mixed results when encoding from UTF-16 and since x86 and
                      // x86_64 should be using SSE2 in due course, keeping the move
                      // to alignment here. It would be good to test on more ARM CPUs
                      // and on real MIPS and POWER hardware.
@@ -650,7 +1040,7 @@ index 90644de..80233f2 100644
                          if offset > len_minus_stride {
                              break;
                          }
-@@ -262,11 +321,15 @@ macro_rules! basic_latin_alu {
+                     }
                  }
                  break;
              }
@@ -666,7 +1056,10 @@ index 90644de..80233f2 100644
                  *(dst.add(offset)) = code_unit as $dst_unit;
                  offset += 1;
              }
-@@ -277,7 +340,11 @@ macro_rules! basic_latin_alu {
+             None
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! latin1_alu {
@@ -678,7 +1071,9 @@ index 90644de..80233f2 100644
          #[cfg_attr(
              feature = "cargo-clippy",
              allow(never_loop, cast_ptr_alignment, cast_lossless)
-@@ -287,6 +354,8 @@ macro_rules! latin1_alu {
+         )]
+         #[inline(always)]
+         pub unsafe fn $name(src: *const $src_unit, dst: *mut $dst_unit, len: usize) {
              let mut offset = 0usize;
              // This loop is only broken out of as a `goto` forward
              loop {
@@ -687,7 +1082,17 @@ index 90644de..80233f2 100644
                  let mut until_alignment = {
                      if ::core::mem::size_of::<$src_unit>() < ::core::mem::size_of::<$dst_unit>() {
                          // unpack
-@@ -313,19 +382,30 @@ macro_rules! latin1_alu {
+                         let src_until_alignment = (ALU_ALIGNMENT
+                             - ((src as usize) & ALU_ALIGNMENT_MASK))
+                             & ALU_ALIGNMENT_MASK;
+                         if (dst.wrapping_add(src_until_alignment) as usize) & ALU_ALIGNMENT_MASK
+                             != 0
+@@ -308,373 +377,485 @@ macro_rules! latin1_alu {
+                             != 0
+                         {
+                             break;
+                         }
+                         dst_until_alignment
                      }
                  };
                  if until_alignment + ALU_STRIDE_SIZE <= len {
@@ -718,7 +1123,7 @@ index 90644de..80233f2 100644
                          if offset > len_minus_stride {
                              break;
                          }
-@@ -333,7 +413,9 @@ macro_rules! latin1_alu {
+                     }
                  }
                  break;
              }
@@ -728,7 +1133,14 @@ index 90644de..80233f2 100644
                  let code_unit = *(src.add(offset));
                  *(dst.add(offset)) = code_unit as $dst_unit;
                  offset += 1;
-@@ -348,11 +430,19 @@ macro_rules! ascii_simd_check_align {
+             }
+         }
+     };
+ }
+ 
+ #[allow(unused_macros)]
+ macro_rules! ascii_simd_check_align {
+     (
          $name:ident,
          $src_unit:ty,
          $dst_unit:ty,
@@ -748,7 +1160,7 @@ index 90644de..80233f2 100644
          #[inline(always)]
          pub unsafe fn $name(
              src: *const $src_unit,
-@@ -360,6 +450,7 @@ macro_rules! ascii_simd_check_align {
+             dst: *mut $dst_unit,
              len: usize,
          ) -> Option<($src_unit, usize)> {
              let mut offset = 0usize;
@@ -756,7 +1168,8 @@ index 90644de..80233f2 100644
              if SIMD_STRIDE_SIZE <= len {
                  let len_minus_stride = len - SIMD_STRIDE_SIZE;
                  // XXX Should we first process one stride unconditionally as unaligned to
-@@ -368,23 +459,29 @@ macro_rules! ascii_simd_check_align {
+                 // avoid the cost of the branchiness below if the first stride fails anyway?
+                 // XXX Should we just use unaligned SSE2 access unconditionally? It seems that
                  // on Haswell, it would make sense to just use unaligned and not bother
                  // checking. Need to benchmark older architectures before deciding.
                  let dst_masked = (dst as usize) & SIMD_ALIGNMENT_MASK;
@@ -786,7 +1199,8 @@ index 90644de..80233f2 100644
                              if offset > len_minus_stride {
                                  break;
                              }
-@@ -393,20 +490,24 @@ macro_rules! ascii_simd_check_align {
+                         }
+                     }
                  } else {
                      if dst_masked == 0 {
                          loop {
@@ -811,7 +1225,8 @@ index 90644de..80233f2 100644
                              if offset > len_minus_stride {
                                  break;
                              }
-@@ -415,8 +516,10 @@ macro_rules! ascii_simd_check_align {
+                         }
+                     }
                  }
              }
              while offset < len {
@@ -822,7 +1237,16 @@ index 90644de..80233f2 100644
                      return Some((code_unit, offset));
                  }
                  *(dst.add(offset)) = code_unit as $dst_unit;
-@@ -433,13 +536,21 @@ macro_rules! ascii_simd_check_align_unrolled {
+                 offset += 1;
+             }
+             None
+         }
+     };
+ }
+ 
+ #[allow(unused_macros)]
+ macro_rules! ascii_simd_check_align_unrolled {
+     (
          $name:ident,
          $src_unit:ty,
          $dst_unit:ty,
@@ -845,7 +1269,10 @@ index 90644de..80233f2 100644
          pub unsafe fn $name(
              src: *const $src_unit,
              dst: *mut $dst_unit,
-@@ -450,8 +561,10 @@ macro_rules! ascii_simd_check_align_unrolled {
+             len: usize,
+         ) -> Option<($src_unit, usize)> {
+             let unit_size = ::core::mem::size_of::<$src_unit>();
+             let mut offset = 0usize;
              // This loop is only broken out of as a goto forward without
              // actually looping
              'outer: loop {
@@ -856,7 +1283,9 @@ index 90644de..80233f2 100644
                      if !$stride_neither_aligned(src, dst) {
                          break 'outer;
                      }
-@@ -461,37 +574,54 @@ macro_rules! ascii_simd_check_align_unrolled {
+                     offset = SIMD_STRIDE_SIZE;
+ 
+                     // We have now seen 16 ASCII bytes. Let's guess that
                      // there will be enough more to justify more expense
                      // in the case of non-ASCII.
                      // Use aligned reads for the sake of old microachitectures.
@@ -912,7 +1341,8 @@ index 90644de..80233f2 100644
                              if offset + SIMD_STRIDE_SIZE <= len {
                                  if !$stride_both_aligned(src.add(offset), dst.add(offset)) {
                                      break 'outer;
-@@ -500,18 +630,25 @@ macro_rules! ascii_simd_check_align_unrolled {
+                                 }
+                                 offset += SIMD_STRIDE_SIZE;
                              }
                          } else {
                              loop {
@@ -938,7 +1368,10 @@ index 90644de..80233f2 100644
                              if offset + SIMD_STRIDE_SIZE <= len {
                                  if !$stride_src_aligned(src.add(offset), dst.add(offset)) {
                                      break 'outer;
-@@ -522,11 +659,13 @@ macro_rules! ascii_simd_check_align_unrolled {
+                                 }
+                                 offset += SIMD_STRIDE_SIZE;
+                             }
+                         }
                      } else {
                          // At most two iterations, so unroll
                          if offset + SIMD_STRIDE_SIZE <= len {
@@ -952,7 +1385,11 @@ index 90644de..80233f2 100644
                                  if !$stride_neither_aligned(src.add(offset), dst.add(offset)) {
                                      break;
                                  }
-@@ -538,8 +677,10 @@ macro_rules! ascii_simd_check_align_unrolled {
+                                 offset += SIMD_STRIDE_SIZE;
+                             }
+                         }
+                     }
+                 }
                  break 'outer;
              }
              while offset < len {
@@ -963,7 +1400,16 @@ index 90644de..80233f2 100644
                      return Some((code_unit, offset));
                  }
                  *(dst.add(offset)) = code_unit as $dst_unit;
-@@ -556,30 +697,45 @@ macro_rules! latin1_simd_check_align {
+                 offset += 1;
+             }
+             None
+         }
+     };
+ }
+ 
+ #[allow(unused_macros)]
+ macro_rules! latin1_simd_check_align {
+     (
          $name:ident,
          $src_unit:ty,
          $dst_unit:ty,
@@ -1009,7 +1455,8 @@ index 90644de..80233f2 100644
                              if offset > len_minus_stride {
                                  break;
                              }
-@@ -588,16 +744,22 @@ macro_rules! latin1_simd_check_align {
+                         }
+                     }
                  } else {
                      if dst_masked == 0 {
                          loop {
@@ -1032,7 +1479,8 @@ index 90644de..80233f2 100644
                              if offset > len_minus_stride {
                                  break;
                              }
-@@ -606,6 +768,7 @@ macro_rules! latin1_simd_check_align {
+                         }
+                     }
                  }
              }
              while offset < len {
@@ -1040,7 +1488,14 @@ index 90644de..80233f2 100644
                  let code_unit = *(src.add(offset));
                  *(dst.add(offset)) = code_unit as $dst_unit;
                  offset += 1;
-@@ -620,56 +783,74 @@ macro_rules! latin1_simd_check_align_unrolled {
+             }
+         }
+     };
+ }
+ 
+ #[allow(unused_macros)]
+ macro_rules! latin1_simd_check_align_unrolled {
+     (
          $name:ident,
          $src_unit:ty,
          $dst_unit:ty,
@@ -1115,7 +1570,17 @@ index 90644de..80233f2 100644
                  let code_unit = *(src.add(offset));
                  // On x86_64, this loop autovectorizes but in the pack
                  // case there are instructions whose purpose is to make sure
-@@ -693,7 +874,12 @@ macro_rules! latin1_simd_check_align_unrolled {
+                 // each u16 in the vector is truncated before packing. However,
+                 // since we don't care about saturating behavior of SSE2 packing
+                 // when the input isn't Latin1, those instructions are useless.
+                 // Unfortunately, using the `assume` intrinsic to lie to the
+                 // optimizer doesn't make LLVM omit the trunctation that we
+@@ -688,138 +869,180 @@ macro_rules! latin1_simd_check_align_unr
+                 offset += 1;
+             }
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! ascii_simd_unalign {
@@ -1128,7 +1593,7 @@ index 90644de..80233f2 100644
          #[inline(always)]
          pub unsafe fn $name(
              src: *const $src_unit,
-@@ -701,21 +887,26 @@ macro_rules! ascii_simd_unalign {
+             dst: *mut $dst_unit,
              len: usize,
          ) -> Option<($src_unit, usize)> {
              let mut offset = 0usize;
@@ -1155,7 +1620,12 @@ index 90644de..80233f2 100644
                      return Some((code_unit, offset));
                  }
                  *(dst.add(offset)) = code_unit as $dst_unit;
-@@ -728,21 +919,27 @@ macro_rules! ascii_simd_unalign {
+                 offset += 1;
+             }
+             None
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! latin1_simd_unalign {
@@ -1183,7 +1653,10 @@ index 90644de..80233f2 100644
                  let code_unit = *(src.add(offset));
                  *(dst.add(offset)) = code_unit as $dst_unit;
                  offset += 1;
-@@ -753,7 +950,11 @@ macro_rules! latin1_simd_unalign {
+             }
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! ascii_to_ascii_simd_stride {
@@ -1195,7 +1668,14 @@ index 90644de..80233f2 100644
          #[inline(always)]
          pub unsafe fn $name(src: *const u8, dst: *mut u8) -> bool {
              let simd = $load(src);
-@@ -768,19 +969,32 @@ macro_rules! ascii_to_ascii_simd_stride {
+             if !simd_is_ascii(simd) {
+                 return false;
+             }
+             $store(dst, simd);
+             true
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! ascii_to_ascii_simd_double_stride {
@@ -1228,7 +1708,10 @@ index 90644de..80233f2 100644
                  return Some(SIMD_STRIDE_SIZE + mask_second.trailing_zeros() as usize);
              }
              $store(dst.add(SIMD_STRIDE_SIZE), second);
-@@ -791,7 +1005,11 @@ macro_rules! ascii_to_ascii_simd_double_stride {
+             None
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! ascii_to_basic_latin_simd_stride {
@@ -1240,7 +1723,16 @@ index 90644de..80233f2 100644
          #[inline(always)]
          pub unsafe fn $name(src: *const u8, dst: *mut u16) -> bool {
              let simd = $load(src);
-@@ -808,13 +1026,18 @@ macro_rules! ascii_to_basic_latin_simd_stride {
+             if !simd_is_ascii(simd) {
+                 return false;
+             }
+             let (first, second) = simd_unpack(simd);
+             $store(dst, first);
+             $store(dst.add(8), second);
+             true
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! ascii_to_basic_latin_simd_double_stride {
@@ -1259,7 +1751,17 @@ index 90644de..80233f2 100644
              $store(dst.add(SIMD_STRIDE_SIZE / 2), b);
              if unlikely(!simd_is_ascii(first | second)) {
                  let mask_first = mask_ascii(first);
-@@ -837,7 +1060,11 @@ macro_rules! ascii_to_basic_latin_simd_double_stride {
+                 if mask_first != 0 {
+                     return Some(mask_first.trailing_zeros() as usize);
+                 }
+                 let (c, d) = simd_unpack(second);
+                 $store(dst.add(SIMD_STRIDE_SIZE), c);
+@@ -832,47 +1055,59 @@ macro_rules! ascii_to_basic_latin_simd_d
+             $store(dst.add(SIMD_STRIDE_SIZE + (SIMD_STRIDE_SIZE / 2)), d);
+             None
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! unpack_simd_stride {
@@ -1271,7 +1773,12 @@ index 90644de..80233f2 100644
          #[inline(always)]
          pub unsafe fn $name(src: *const u8, dst: *mut u16) {
              let simd = $load(src);
-@@ -850,7 +1077,11 @@ macro_rules! unpack_simd_stride {
+             let (first, second) = simd_unpack(simd);
+             $store(dst, first);
+             $store(dst.add(8), second);
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! basic_latin_to_ascii_simd_stride {
@@ -1283,7 +1790,16 @@ index 90644de..80233f2 100644
          #[inline(always)]
          pub unsafe fn $name(src: *const u16, dst: *mut u8) -> bool {
              let first = $load(src);
-@@ -867,7 +1098,11 @@ macro_rules! basic_latin_to_ascii_simd_stride {
+             let second = $load(src.add(8));
+             if simd_is_basic_latin(first | second) {
+                 $store(dst, simd_pack(first, second));
+                 true
+             } else {
+                 false
+             }
+         }
+     };
+ }
  
  #[allow(unused_macros)]
  macro_rules! pack_simd_stride {
@@ -1295,7 +1811,17 @@ index 90644de..80233f2 100644
          #[inline(always)]
          pub unsafe fn $name(src: *const u16, dst: *mut u8) {
              let first = $load(src);
-@@ -893,6 +1128,8 @@ cfg_if! {
+             let second = $load(src.add(8));
+             $store(dst, simd_pack(first, second));
+         }
+     };
+ }
+@@ -888,24 +1123,28 @@ cfg_if! {
+ //        pub const ALIGNMENT: usize = 8;
+ 
+         pub const ALU_STRIDE_SIZE: usize = 16;
+ 
+         pub const ALU_ALIGNMENT: usize = 8;
  
          pub const ALU_ALIGNMENT_MASK: usize = 7;
  
@@ -1304,7 +1830,8 @@ index 90644de..80233f2 100644
          ascii_to_ascii_simd_stride!(ascii_to_ascii_stride_neither_aligned, load16_unaligned, store16_unaligned);
  
          ascii_to_basic_latin_simd_stride!(ascii_to_basic_latin_stride_neither_aligned, load16_unaligned, store8_unaligned);
-@@ -901,6 +1138,8 @@ cfg_if! {
+         unpack_simd_stride!(unpack_stride_neither_aligned, load16_unaligned, store8_unaligned);
+ 
          basic_latin_to_ascii_simd_stride!(basic_latin_to_ascii_stride_neither_aligned, load8_unaligned, store16_unaligned);
          pack_simd_stride!(pack_stride_neither_aligned, load8_unaligned, store16_unaligned);
  
@@ -1313,7 +1840,17 @@ index 90644de..80233f2 100644
          ascii_simd_unalign!(ascii_to_ascii, u8, u8, ascii_to_ascii_stride_neither_aligned);
          ascii_simd_unalign!(ascii_to_basic_latin, u8, u16, ascii_to_basic_latin_stride_neither_aligned);
          ascii_simd_unalign!(basic_latin_to_ascii, u16, u8, basic_latin_to_ascii_stride_neither_aligned);
-@@ -919,6 +1158,9 @@ cfg_if! {
+         latin1_simd_unalign!(unpack_latin1, u8, u16, unpack_stride_neither_aligned);
+         latin1_simd_unalign!(pack_latin1, u16, u8, pack_stride_neither_aligned);
+     } else if #[cfg(all(feature = "simd-accel", target_endian = "little", target_feature = "neon"))] {
+         // SIMD with different instructions for aligned and unaligned loads and stores.
+         //
+@@ -914,16 +1153,19 @@ cfg_if! {
+         // but the benchmark results I see don't agree.
+ 
+         pub const SIMD_STRIDE_SIZE: usize = 16;
+ 
+         pub const MAX_STRIDE_SIZE: usize = 16;
  
          pub const SIMD_ALIGNMENT_MASK: usize = 15;
  
@@ -1323,7 +1860,17 @@ index 90644de..80233f2 100644
          ascii_to_ascii_simd_stride!(ascii_to_ascii_stride_both_aligned, load16_aligned, store16_aligned);
          ascii_to_ascii_simd_stride!(ascii_to_ascii_stride_src_aligned, load16_aligned, store16_unaligned);
          ascii_to_ascii_simd_stride!(ascii_to_ascii_stride_dst_aligned, load16_unaligned, store16_aligned);
-@@ -944,6 +1186,9 @@ cfg_if! {
+         ascii_to_ascii_simd_stride!(ascii_to_ascii_stride_neither_aligned, load16_unaligned, store16_unaligned);
+ 
+         ascii_to_basic_latin_simd_stride!(ascii_to_basic_latin_stride_both_aligned, load16_aligned, store8_aligned);
+         ascii_to_basic_latin_simd_stride!(ascii_to_basic_latin_stride_src_aligned, load16_aligned, store8_unaligned);
+         ascii_to_basic_latin_simd_stride!(ascii_to_basic_latin_stride_dst_aligned, load16_unaligned, store8_aligned);
+@@ -939,36 +1181,43 @@ cfg_if! {
+         basic_latin_to_ascii_simd_stride!(basic_latin_to_ascii_stride_dst_aligned, load8_unaligned, store16_aligned);
+         basic_latin_to_ascii_simd_stride!(basic_latin_to_ascii_stride_neither_aligned, load8_unaligned, store16_unaligned);
+ 
+         pack_simd_stride!(pack_stride_both_aligned, load8_aligned, store16_aligned);
+         pack_simd_stride!(pack_stride_src_aligned, load8_aligned, store16_unaligned);
          pack_simd_stride!(pack_stride_dst_aligned, load8_unaligned, store16_aligned);
          pack_simd_stride!(pack_stride_neither_aligned, load8_unaligned, store16_unaligned);
  
@@ -1333,7 +1880,14 @@ index 90644de..80233f2 100644
          ascii_simd_check_align!(ascii_to_ascii, u8, u8, ascii_to_ascii_stride_both_aligned, ascii_to_ascii_stride_src_aligned, ascii_to_ascii_stride_dst_aligned, ascii_to_ascii_stride_neither_aligned);
          ascii_simd_check_align!(ascii_to_basic_latin, u8, u16, ascii_to_basic_latin_stride_both_aligned, ascii_to_basic_latin_stride_src_aligned, ascii_to_basic_latin_stride_dst_aligned, ascii_to_basic_latin_stride_neither_aligned);
          ascii_simd_check_align!(basic_latin_to_ascii, u16, u8, basic_latin_to_ascii_stride_both_aligned, basic_latin_to_ascii_stride_src_aligned, basic_latin_to_ascii_stride_dst_aligned, basic_latin_to_ascii_stride_neither_aligned);
-@@ -958,12 +1203,16 @@ cfg_if! {
+         latin1_simd_check_align!(unpack_latin1, u8, u16, unpack_stride_both_aligned, unpack_stride_src_aligned, unpack_stride_dst_aligned, unpack_stride_neither_aligned);
+         latin1_simd_check_align!(pack_latin1, u16, u8, pack_stride_both_aligned, pack_stride_src_aligned, pack_stride_dst_aligned, pack_stride_neither_aligned);
+     } else if #[cfg(all(feature = "simd-accel", target_feature = "sse2"))] {
+         // SIMD with different instructions for aligned and unaligned loads and stores.
+         //
+         // Newer microarchitectures are not supposed to have a performance difference between
+         // aligned and unaligned SSE2 loads and stores when the address is actually aligned,
+         // but the benchmark results I see don't agree.
  
          pub const SIMD_STRIDE_SIZE: usize = 16;
  
@@ -1350,7 +1904,17 @@ index 90644de..80233f2 100644
          ascii_to_ascii_simd_double_stride!(ascii_to_ascii_simd_double_stride_both_aligned, store16_aligned);
          ascii_to_ascii_simd_double_stride!(ascii_to_ascii_simd_double_stride_src_aligned, store16_unaligned);
  
-@@ -989,6 +1238,9 @@ cfg_if! {
+         ascii_to_basic_latin_simd_double_stride!(ascii_to_basic_latin_simd_double_stride_both_aligned, store8_aligned);
+         ascii_to_basic_latin_simd_double_stride!(ascii_to_basic_latin_simd_double_stride_src_aligned, store8_unaligned);
+ 
+         ascii_to_ascii_simd_stride!(ascii_to_ascii_stride_both_aligned, load16_aligned, store16_aligned);
+         ascii_to_ascii_simd_stride!(ascii_to_ascii_stride_src_aligned, load16_aligned, store16_unaligned);
+@@ -984,33 +1233,43 @@ cfg_if! {
+         basic_latin_to_ascii_simd_stride!(basic_latin_to_ascii_stride_both_aligned, load8_aligned, store16_aligned);
+         basic_latin_to_ascii_simd_stride!(basic_latin_to_ascii_stride_src_aligned, load8_aligned, store16_unaligned);
+         basic_latin_to_ascii_simd_stride!(basic_latin_to_ascii_stride_dst_aligned, load8_unaligned, store16_aligned);
+         basic_latin_to_ascii_simd_stride!(basic_latin_to_ascii_stride_neither_aligned, load8_unaligned, store16_unaligned);
+ 
          pack_simd_stride!(pack_stride_both_aligned, load8_aligned, store16_aligned);
          pack_simd_stride!(pack_stride_src_aligned, load8_aligned, store16_unaligned);
  
@@ -1360,7 +1924,9 @@ index 90644de..80233f2 100644
          ascii_simd_check_align_unrolled!(ascii_to_ascii, u8, u8, ascii_to_ascii_stride_both_aligned, ascii_to_ascii_stride_src_aligned, ascii_to_ascii_stride_neither_aligned, ascii_to_ascii_simd_double_stride_both_aligned, ascii_to_ascii_simd_double_stride_src_aligned);
          ascii_simd_check_align_unrolled!(ascii_to_basic_latin, u8, u16, ascii_to_basic_latin_stride_both_aligned, ascii_to_basic_latin_stride_src_aligned, ascii_to_basic_latin_stride_neither_aligned, ascii_to_basic_latin_simd_double_stride_both_aligned, ascii_to_basic_latin_simd_double_stride_src_aligned);
  
-@@ -998,14 +1250,21 @@ cfg_if! {
+         ascii_simd_check_align!(basic_latin_to_ascii, u16, u8, basic_latin_to_ascii_stride_both_aligned, basic_latin_to_ascii_stride_src_aligned, basic_latin_to_ascii_stride_dst_aligned, basic_latin_to_ascii_stride_neither_aligned);
+         latin1_simd_check_align_unrolled!(unpack_latin1, u8, u16, unpack_stride_both_aligned, unpack_stride_src_aligned, unpack_stride_dst_aligned, unpack_stride_neither_aligned);
+         latin1_simd_check_align_unrolled!(pack_latin1, u16, u8, pack_stride_both_aligned, pack_stride_src_aligned, pack_stride_dst_aligned, pack_stride_neither_aligned);
      } else if #[cfg(all(target_endian = "little", target_pointer_width = "64"))] {
          // Aligned ALU word, little-endian, 64-bit
  
@@ -1382,7 +1948,17 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn unpack_alu(word: usize, second_word: usize, dst: *mut usize) {
              let first = ((0x0000_0000_FF00_0000usize & word) << 24) |
-@@ -1024,12 +1283,14 @@ cfg_if! {
+                         ((0x0000_0000_00FF_0000usize & word) << 16) |
+                         ((0x0000_0000_0000_FF00usize & word) << 8) |
+                         (0x0000_0000_0000_00FFusize & word);
+             let second = ((0xFF00_0000_0000_0000usize & word) >> 8) |
+                          ((0x00FF_0000_0000_0000usize & word) >> 16) |
+@@ -1019,22 +1278,24 @@ cfg_if! {
+             let third = ((0x0000_0000_FF00_0000usize & second_word) << 24) |
+                         ((0x0000_0000_00FF_0000usize & second_word) << 16) |
+                         ((0x0000_0000_0000_FF00usize & second_word) << 8) |
+                         (0x0000_0000_0000_00FFusize & second_word);
+             let fourth = ((0xFF00_0000_0000_0000usize & second_word) >> 8) |
                           ((0x00FF_0000_0000_0000usize & second_word) >> 16) |
                           ((0x0000_FF00_0000_0000usize & second_word) >> 24) |
                           ((0x0000_00FF_0000_0000usize & second_word) >> 32);
@@ -1397,7 +1973,17 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn pack_alu(first: usize, second: usize, third: usize, fourth: usize, dst: *mut usize) {
              let word = ((0x00FF_0000_0000_0000usize & second) << 8) |
-@@ -1048,20 +1309,28 @@ cfg_if! {
+                        ((0x0000_00FF_0000_0000usize & second) << 16) |
+                        ((0x0000_0000_00FF_0000usize & second) << 24) |
+                        ((0x0000_0000_0000_00FFusize & second) << 32) |
+                        ((0x00FF_0000_0000_0000usize & first) >> 24) |
+                        ((0x0000_00FF_0000_0000usize & first) >> 16) |
+@@ -1043,70 +1304,88 @@ cfg_if! {
+             let second_word = ((0x00FF_0000_0000_0000usize & fourth) << 8) |
+                               ((0x0000_00FF_0000_0000usize & fourth) << 16) |
+                               ((0x0000_0000_00FF_0000usize & fourth) << 24) |
+                               ((0x0000_0000_0000_00FFusize & fourth) << 32) |
+                               ((0x00FF_0000_0000_0000usize & third) >> 24) |
                                ((0x0000_00FF_0000_0000usize & third) >> 16) |
                                ((0x0000_0000_00FF_0000usize & third) >> 8) |
                                (0x0000_0000_0000_00FFusize & third);
@@ -1426,7 +2012,10 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn unpack_alu(word: usize, second_word: usize, dst: *mut usize) {
              let first = ((0x0000_FF00usize & word) << 8) |
-@@ -1072,12 +1341,14 @@ cfg_if! {
+                         (0x0000_00FFusize & word);
+             let second = ((0xFF00_0000usize & word) >> 8) |
+                          ((0x00FF_0000usize & word) >> 16);
+             let third = ((0x0000_FF00usize & second_word) << 8) |
                          (0x0000_00FFusize & second_word);
              let fourth = ((0xFF00_0000usize & second_word) >> 8) |
                           ((0x00FF_0000usize & second_word) >> 16);
@@ -1441,7 +2030,10 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn pack_alu(first: usize, second: usize, third: usize, fourth: usize, dst: *mut usize) {
              let word = ((0x00FF_0000usize & second) << 8) |
-@@ -1088,20 +1359,28 @@ cfg_if! {
+                        ((0x0000_00FFusize & second) << 16) |
+                        ((0x00FF_0000usize & first) >> 8) |
+                        (0x0000_00FFusize & first);
+             let second_word = ((0x00FF_0000usize & fourth) << 8) |
                                ((0x0000_00FFusize & fourth) << 16) |
                                ((0x00FF_0000usize & third) >> 8) |
                                (0x0000_00FFusize & third);
@@ -1470,7 +2062,17 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn unpack_alu(word: usize, second_word: usize, dst: *mut usize) {
              let first = ((0xFF00_0000_0000_0000usize & word) >> 8) |
-@@ -1120,12 +1399,14 @@ cfg_if! {
+                          ((0x00FF_0000_0000_0000usize & word) >> 16) |
+                          ((0x0000_FF00_0000_0000usize & word) >> 24) |
+                          ((0x0000_00FF_0000_0000usize & word) >> 32);
+             let second = ((0x0000_0000_FF00_0000usize & word) << 24) |
+                         ((0x0000_0000_00FF_0000usize & word) << 16) |
+@@ -1115,22 +1394,24 @@ cfg_if! {
+             let third = ((0xFF00_0000_0000_0000usize & second_word) >> 8) |
+                          ((0x00FF_0000_0000_0000usize & second_word) >> 16) |
+                          ((0x0000_FF00_0000_0000usize & second_word) >> 24) |
+                          ((0x0000_00FF_0000_0000usize & second_word) >> 32);
+             let fourth = ((0x0000_0000_FF00_0000usize & second_word) << 24) |
                          ((0x0000_0000_00FF_0000usize & second_word) << 16) |
                          ((0x0000_0000_0000_FF00usize & second_word) << 8) |
                          (0x0000_0000_0000_00FFusize & second_word);
@@ -1485,7 +2087,17 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn pack_alu(first: usize, second: usize, third: usize, fourth: usize, dst: *mut usize) {
              let word = ((0x00FF0000_00000000usize & first) << 8) |
-@@ -1144,20 +1425,28 @@ cfg_if! {
+                        ((0x000000FF_00000000usize & first) << 16) |
+                        ((0x00000000_00FF0000usize & first) << 24) |
+                        ((0x00000000_000000FFusize & first) << 32) |
+                        ((0x00FF0000_00000000usize & second) >> 24) |
+                        ((0x000000FF_00000000usize & second) >> 16) |
+@@ -1139,67 +1420,80 @@ cfg_if! {
+             let second_word = ((0x00FF0000_00000000usize & third) << 8) |
+                               ((0x000000FF_00000000usize & third) << 16) |
+                               ((0x00000000_00FF0000usize & third) << 24) |
+                               ((0x00000000_000000FFusize & third) << 32) |
+                               ((0x00FF0000_00000000usize & fourth) >> 24) |
                                ((0x000000FF_00000000usize & fourth) >> 16) |
                                ((0x00000000_00FF0000usize & fourth) >> 8) |
                                (0x00000000_000000FFusize &  fourth);
@@ -1514,7 +2126,10 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn unpack_alu(word: usize, second_word: usize, dst: *mut usize) {
              let first = ((0xFF00_0000usize & word) >> 8) |
-@@ -1168,12 +1457,14 @@ cfg_if! {
+                          ((0x00FF_0000usize & word) >> 16);
+             let second = ((0x0000_FF00usize & word) << 8) |
+                         (0x0000_00FFusize & word);
+             let third = ((0xFF00_0000usize & second_word) >> 8) |
                           ((0x00FF_0000usize & second_word) >> 16);
              let fourth = ((0x0000_FF00usize & second_word) << 8) |
                          (0x0000_00FFusize & second_word);
@@ -1529,7 +2144,10 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn pack_alu(first: usize, second: usize, third: usize, fourth: usize, dst: *mut usize) {
              let word = ((0x00FF_0000usize & first) << 8) |
-@@ -1184,6 +1475,7 @@ cfg_if! {
+                        ((0x0000_00FFusize & first) << 16) |
+                        ((0x00FF_0000usize & second) >> 8) |
+                        (0x0000_00FFusize & second);
+             let second_word = ((0x00FF_0000usize & third) << 8) |
                                ((0x0000_00FFusize & third) << 16) |
                                ((0x00FF_0000usize & fourth) >> 8) |
                                (0x0000_00FFusize & fourth);
@@ -1537,7 +2155,11 @@ index 90644de..80233f2 100644
              *dst = word;
              *(dst.add(1)) = second_word;
          }
-@@ -1195,6 +1487,8 @@ cfg_if! {
+     } else {
+         ascii_naive!(ascii_to_ascii, u8, u8);
+         ascii_naive!(ascii_to_basic_latin, u8, u16);
+         ascii_naive!(basic_latin_to_ascii, u16, u8);
+     }
  }
  
  cfg_if! {
@@ -1546,7 +2168,17 @@ index 90644de..80233f2 100644
      if #[cfg(target_endian = "little")] {
          #[allow(dead_code)]
          #[inline(always)]
-@@ -1212,19 +1506,24 @@ cfg_if! {
+         fn count_zeros(word: usize) -> u32 {
+             word.trailing_zeros()
+         }
+     } else {
+         #[allow(dead_code)]
+@@ -1207,208 +1501,272 @@ cfg_if! {
+         fn count_zeros(word: usize) -> u32 {
+             word.leading_zeros()
+         }
+     }
+ }
  
  cfg_if! {
      if #[cfg(all(feature = "simd-accel", target_endian = "little", target_arch = "disabled"))] {
@@ -1571,7 +2203,8 @@ index 90644de..80233f2 100644
                      if offset > len_minus_stride {
                          break;
                      }
-@@ -1233,6 +1532,7 @@ cfg_if! {
+                 }
+             }
              while offset < len {
                  let code_unit = slice[offset];
                  if code_unit > 127 {
@@ -1579,7 +2212,7 @@ index 90644de..80233f2 100644
                      return Some((code_unit, offset));
                  }
                  offset += 1;
-@@ -1240,13 +1540,17 @@ cfg_if! {
+             }
              None
          }
      } else if #[cfg(all(feature = "simd-accel", target_feature = "sse2"))] {
@@ -1597,7 +2230,8 @@ index 90644de..80233f2 100644
                  let simd = unsafe { load16_unaligned(src) };
                  let mask = mask_ascii(simd);
                  if mask != 0 {
-@@ -1255,18 +1559,26 @@ cfg_if! {
+                     offset = mask.trailing_zeros() as usize;
+                     let non_ascii = unsafe { *src.add(offset) };
                      return Some((non_ascii, offset));
                  }
                  offset = SIMD_STRIDE_SIZE;
@@ -1624,7 +2258,9 @@ index 90644de..80233f2 100644
                          let simd = unsafe { load16_unaligned(src.add(offset)) };
                          let mask = mask_ascii(simd);
                          if mask != 0 {
-@@ -1276,53 +1588,78 @@ cfg_if! {
+                             offset += mask.trailing_zeros() as usize;
+                             let non_ascii = unsafe { *src.add(offset) };
+                             return Some((non_ascii, offset));
                          }
                          offset += until_alignment;
                      }
@@ -1705,7 +2341,8 @@ index 90644de..80233f2 100644
                                  return Some((non_ascii, offset));
                              }
                              offset += SIMD_STRIDE_SIZE;
-@@ -1331,8 +1668,10 @@ cfg_if! {
+                         }
+                     }
                  }
              }
              while offset < len {
@@ -1716,7 +2353,7 @@ index 90644de..80233f2 100644
                      return Some((code_unit, offset));
                  }
                  offset += 1;
-@@ -1340,31 +1679,40 @@ cfg_if! {
+             }
              None
          }
      } else {
@@ -1759,7 +2396,7 @@ index 90644de..80233f2 100644
          #[inline(always)]
          unsafe fn validate_ascii_stride(src: *const usize) -> Option<usize> {
              let word = *src;
-@@ -1372,6 +1720,8 @@ cfg_if! {
+             let second_word = *(src.add(1));
              find_non_ascii(word, second_word)
          }
  
@@ -1768,7 +2405,7 @@ index 90644de..80233f2 100644
          #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
          #[inline(always)]
          pub fn validate_ascii(slice: &[u8]) -> Option<(u8, usize)> {
-@@ -1379,23 +1729,30 @@ cfg_if! {
+             let src = slice.as_ptr();
              let len = slice.len();
              let mut offset = 0usize;
              let mut until_alignment = (ALU_ALIGNMENT - ((src as usize) & ALU_ALIGNMENT_MASK)) & ALU_ALIGNMENT_MASK;
@@ -1799,7 +2436,8 @@ index 90644de..80233f2 100644
                      if offset > len_minus_stride {
                          break;
                      }
-@@ -1404,6 +1761,7 @@ cfg_if! {
+                 }
+             }
              while offset < len {
                  let code_unit = slice[offset];
                  if code_unit > 127 {
@@ -1807,7 +2445,17 @@ index 90644de..80233f2 100644
                      return Some((code_unit, offset));
                  }
                  offset += 1;
-@@ -1428,36 +1786,47 @@ cfg_if! {
+            }
+            None
+         }
+ 
+     }
+@@ -1423,70 +1781,88 @@ cfg_if! {
+         // vector reads without vector writes.
+ 
+         pub const ALU_STRIDE_SIZE: usize = 8;
+ 
+         pub const ALU_ALIGNMENT: usize = 4;
  
          pub const ALU_ALIGNMENT_MASK: usize = 3;
      } else {
@@ -1855,7 +2503,7 @@ index 90644de..80233f2 100644
              let first = *src;
              let second = *(src.add(1));
              let third = *(src.add(2));
-@@ -1465,16 +1834,22 @@ cfg_if! {
+             let fourth = *(src.add(3));
              if (first & BASIC_LATIN_MASK) | (second & BASIC_LATIN_MASK) | (third & BASIC_LATIN_MASK) | (fourth & BASIC_LATIN_MASK) != 0 {
                  return false;
              }
@@ -1878,7 +2526,7 @@ index 90644de..80233f2 100644
              find_non_ascii(word, second_word)
          }
  
-@@ -1482,6 +1857,7 @@ cfg_if! {
+         basic_latin_alu!(ascii_to_basic_latin, u8, u16, ascii_to_basic_latin_stride_alu);
          basic_latin_alu!(basic_latin_to_ascii, u16, u8, basic_latin_to_ascii_stride_alu);
          latin1_alu!(unpack_latin1, u8, u16, unpack_latin1_stride_alu);
          latin1_alu!(pack_latin1, u16, u8, pack_latin1_stride_alu);
@@ -1886,11 +2534,20 @@ index 90644de..80233f2 100644
          ascii_alu!(ascii_to_ascii, u8, u8, ascii_to_ascii_stride);
      }
  }
+ 
+ pub fn ascii_valid_up_to(bytes: &[u8]) -> usize {
+     match validate_ascii(bytes) {
+         None => bytes.len(),
+         Some((_, num_valid)) => num_valid,
 diff --git a/third_party/rust/encoding_rs/src/handles.rs b/third_party/rust/encoding_rs/src/handles.rs
-index b5404c0..f44a834 100644
 --- a/third_party/rust/encoding_rs/src/handles.rs
 +++ b/third_party/rust/encoding_rs/src/handles.rs
-@@ -34,7 +34,7 @@ use crate::simd_funcs::*;
+@@ -29,17 +29,17 @@ use crate::simd_funcs::*;
+ #[cfg(all(
+     feature = "simd-accel",
+     any(
+         target_feature = "sse2",
+         all(target_endian = "little", target_arch = "aarch64"),
          all(target_endian = "little", target_feature = "neon")
      )
  ))]
@@ -1899,7 +2556,17 @@ index b5404c0..f44a834 100644
  
  use super::DecoderResult;
  use super::EncoderResult;
-@@ -90,19 +90,23 @@ impl Endian for LittleEndian {
+ use crate::ascii::*;
+ use crate::utf_8::convert_utf8_to_utf16_up_to_invalid;
+ use crate::utf_8::utf8_valid_up_to;
+ 
+ pub enum Space<T> {
+@@ -85,84 +85,100 @@ impl Endian for LittleEndian {
+     const OPPOSITE_ENDIAN: bool = false;
+ 
+     #[cfg(target_endian = "big")]
+     const OPPOSITE_ENDIAN: bool = true;
+ }
  
  #[derive(Debug, Copy, Clone)]
  struct UnalignedU16Slice {
@@ -1923,7 +2590,10 @@ index b5404c0..f44a834 100644
          self.len -= 1;
      }
  
-@@ -113,7 +117,9 @@ impl UnalignedU16Slice {
+     #[inline(always)]
+     pub fn at(&self, i: usize) -> u16 {
+         use core::mem::MaybeUninit;
+ 
          assert!(i < self.len);
          unsafe {
              let mut u: MaybeUninit<u16> = MaybeUninit::uninit();
@@ -1933,7 +2603,7 @@ index b5404c0..f44a834 100644
              u.assume_init()
          }
      }
-@@ -121,8 +127,13 @@ impl UnalignedU16Slice {
+ 
      #[cfg(feature = "simd-accel")]
      #[inline(always)]
      pub fn simd_at(&self, i: usize) -> u16x8 {
@@ -1947,7 +2617,13 @@ index b5404c0..f44a834 100644
          unsafe { to_u16_lanes(load16_unaligned(self.ptr.add(byte_index))) }
      }
  
-@@ -136,6 +147,7 @@ impl UnalignedU16Slice {
+     #[inline(always)]
+     pub fn len(&self) -> usize {
+         self.len
+     }
+ 
+     #[inline(always)]
+     pub fn tail(&self, from: usize) -> UnalignedU16Slice {
          // XXX the return value should be restricted not to
          // outlive self.
          assert!(from <= self.len);
@@ -1955,7 +2631,8 @@ index b5404c0..f44a834 100644
          unsafe { UnalignedU16Slice::new(self.ptr.add(from * 2), self.len - from) }
      }
  
-@@ -144,6 +156,8 @@ impl UnalignedU16Slice {
+     #[cfg(feature = "simd-accel")]
+     #[inline(always)]
      pub fn copy_bmp_to<E: Endian>(&self, other: &mut [u16]) -> Option<(u16, usize)> {
          assert!(self.len <= other.len());
          let mut offset = 0;
@@ -1964,7 +2641,7 @@ index b5404c0..f44a834 100644
          if SIMD_STRIDE_SIZE / 2 <= self.len {
              let len_minus_stride = self.len - SIMD_STRIDE_SIZE / 2;
              loop {
-@@ -151,6 +165,7 @@ impl UnalignedU16Slice {
+                 let mut simd = self.simd_at(offset);
                  if E::OPPOSITE_ENDIAN {
                      simd = simd_byte_swap(simd);
                  }
@@ -1972,7 +2649,7 @@ index b5404c0..f44a834 100644
                  unsafe {
                      store8_unaligned(other.as_mut_ptr().add(offset), simd);
                  }
-@@ -158,6 +173,7 @@ impl UnalignedU16Slice {
+                 if contains_surrogates(simd) {
                      break;
                  }
                  offset += SIMD_STRIDE_SIZE / 2;
@@ -1980,7 +2657,17 @@ index b5404c0..f44a834 100644
                  if offset > len_minus_stride {
                      break;
                  }
-@@ -236,6 +252,7 @@ fn copy_unaligned_basic_latin_to_ascii<E: Endian>(
+             }
+         }
+         while offset < self.len {
+             let unit = swap_if_opposite_endian::<E>(self.at(offset));
+             other[offset] = unit;
+@@ -231,33 +247,37 @@ fn copy_unaligned_basic_latin_to_ascii<E
+ #[cfg(feature = "simd-accel")]
+ #[inline(always)]
+ fn copy_unaligned_basic_latin_to_ascii<E: Endian>(
+     src: UnalignedU16Slice,
+     dst: &mut [u8],
  ) -> CopyAsciiResult<usize, (u16, usize)> {
      let len = ::core::cmp::min(src.len(), dst.len());
      let mut offset = 0;
@@ -1988,7 +2675,13 @@ index b5404c0..f44a834 100644
      if SIMD_STRIDE_SIZE <= len {
          let len_minus_stride = len - SIMD_STRIDE_SIZE;
          loop {
-@@ -249,10 +266,13 @@ fn copy_unaligned_basic_latin_to_ascii<E: Endian>(
+             let mut first = src.simd_at(offset);
+             let mut second = src.simd_at(offset + (SIMD_STRIDE_SIZE / 2));
+             if E::OPPOSITE_ENDIAN {
+                 first = simd_byte_swap(first);
+                 second = simd_byte_swap(second);
+             }
+             if !simd_is_basic_latin(first | second) {
                  break;
              }
              let packed = simd_pack(first, second);
@@ -2002,7 +2695,17 @@ index b5404c0..f44a834 100644
              if offset > len_minus_stride {
                  break;
              }
-@@ -637,7 +657,7 @@ impl<'a> Utf16Destination<'a> {
+         }
+     }
+     copy_unaligned_basic_latin_to_ascii_alu::<E>(src.tail(offset), &mut dst[offset..], offset)
+ }
+ 
+@@ -632,94 +652,106 @@ impl<'a> Utf16Destination<'a> {
+     #[inline(always)]
+     fn write_astral(&mut self, astral: u32) {
+         debug_assert!(astral > 0xFFFF);
+         debug_assert!(astral <= 0x10_FFFF);
+         self.write_code_unit((0xD7C0 + (astral >> 10)) as u16);
          self.write_code_unit((0xDC00 + (astral & 0x3FF)) as u16);
      }
      #[inline(always)]
@@ -2011,7 +2714,8 @@ index b5404c0..f44a834 100644
          self.write_code_unit(high);
          self.write_code_unit(low);
      }
-@@ -646,6 +666,7 @@ impl<'a> Utf16Destination<'a> {
+     #[inline(always)]
+     fn write_big5_combination(&mut self, combined: u16, combining: u16) {
          self.write_bmp_excl_ascii(combined);
          self.write_bmp_excl_ascii(combining);
      }
@@ -2019,7 +2723,13 @@ index b5404c0..f44a834 100644
      #[inline(always)]
      pub fn copy_ascii_from_check_space_bmp<'b>(
          &'b mut self,
-@@ -659,6 +680,8 @@ impl<'a> Utf16Destination<'a> {
+         source: &mut ByteSource,
+     ) -> CopyAsciiResult<(DecoderResult, usize, usize), (u8, Utf16BmpHandle<'b, 'a>)> {
+         let non_ascii_ret = {
+             let src_remaining = &source.slice[source.pos..];
+             let dst_remaining = &mut self.slice[self.pos..];
+             let (pending, length) = if dst_remaining.len() < src_remaining.len() {
+                 (DecoderResult::OutputFull, dst_remaining.len())
              } else {
                  (DecoderResult::InputEmpty, src_remaining.len())
              };
@@ -2028,7 +2738,8 @@ index b5404c0..f44a834 100644
              match unsafe {
                  ascii_to_basic_latin(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
              } {
-@@ -667,16 +690,20 @@ impl<'a> Utf16Destination<'a> {
+                 None => {
+                     source.pos += length;
                      self.pos += length;
                      return CopyAsciiResult::Stop((pending, source.pos, self.pos));
                  }
@@ -2049,7 +2760,14 @@ index b5404c0..f44a834 100644
      #[inline(always)]
      pub fn copy_ascii_from_check_space_astral<'b>(
          &'b mut self,
-@@ -691,6 +718,8 @@ impl<'a> Utf16Destination<'a> {
+         source: &mut ByteSource,
+     ) -> CopyAsciiResult<(DecoderResult, usize, usize), (u8, Utf16AstralHandle<'b, 'a>)> {
+         let non_ascii_ret = {
+             let dst_len = self.slice.len();
+             let src_remaining = &source.slice[source.pos..];
+             let dst_remaining = &mut self.slice[self.pos..];
+             let (pending, length) = if dst_remaining.len() < src_remaining.len() {
+                 (DecoderResult::OutputFull, dst_remaining.len())
              } else {
                  (DecoderResult::InputEmpty, src_remaining.len())
              };
@@ -2058,7 +2776,8 @@ index b5404c0..f44a834 100644
              match unsafe {
                  ascii_to_basic_latin(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
              } {
-@@ -699,11 +728,13 @@ impl<'a> Utf16Destination<'a> {
+                 None => {
+                     source.pos += length;
                      self.pos += length;
                      return CopyAsciiResult::Stop((pending, source.pos, self.pos));
                  }
@@ -2072,7 +2791,11 @@ index b5404c0..f44a834 100644
                          non_ascii
                      } else {
                          return CopyAsciiResult::Stop((
-@@ -715,6 +746,7 @@ impl<'a> Utf16Destination<'a> {
+                             DecoderResult::OutputFull,
+                             source.pos,
+                             self.pos,
+                         ));
+                     }
                  }
              }
          };
@@ -2080,11 +2803,20 @@ index b5404c0..f44a834 100644
          CopyAsciiResult::GoOn((non_ascii_ret, Utf16AstralHandle::new(self)))
      }
      #[inline(always)]
+     pub fn copy_utf8_up_to_invalid_from(&mut self, source: &mut ByteSource) {
+         let src_remaining = &source.slice[source.pos..];
+         let dst_remaining = &mut self.slice[self.pos..];
+         let (read, written) = convert_utf8_to_utf16_up_to_invalid(src_remaining, dst_remaining);
+         source.pos += read;
 diff --git a/third_party/rust/encoding_rs/src/lib.rs b/third_party/rust/encoding_rs/src/lib.rs
-index 6cc920e..1faf02e 100644
 --- a/third_party/rust/encoding_rs/src/lib.rs
 +++ b/third_party/rust/encoding_rs/src/lib.rs
-@@ -689,7 +689,7 @@
+@@ -684,37 +684,26 @@
+ //! <tr><td>TIS-620</td><td>windows-874</td></tr>
+ //! </tbody>
+ //! </table>
+ //!
+ //! See the section [_UTF-16LE, UTF-16BE and Unicode Encoding Schemes_](#utf-16le-utf-16be-and-unicode-encoding-schemes)
  //! for discussion about the UTF-16 family.
  
  #![no_std]
@@ -2093,7 +2825,9 @@ index 6cc920e..1faf02e 100644
  
  #[cfg(feature = "alloc")]
  #[cfg_attr(test, macro_use)]
-@@ -699,17 +699,6 @@ extern crate core;
+ extern crate alloc;
+ 
+ extern crate core;
  #[macro_use]
  extern crate cfg_if;
  
@@ -2111,11 +2845,20 @@ index 6cc920e..1faf02e 100644
  #[cfg(feature = "serde")]
  extern crate serde;
  
+ #[cfg(all(test, feature = "serde"))]
+ extern crate bincode;
+ #[cfg(all(test, feature = "serde"))]
+ #[macro_use]
+ extern crate serde_derive;
 diff --git a/third_party/rust/encoding_rs/src/mem.rs b/third_party/rust/encoding_rs/src/mem.rs
-index ba8d9e3..0f9f3c1 100644
 --- a/third_party/rust/encoding_rs/src/mem.rs
 +++ b/third_party/rust/encoding_rs/src/mem.rs
-@@ -116,6 +116,11 @@ macro_rules! by_unit_check_alu {
+@@ -111,16 +111,21 @@ macro_rules! by_unit_check_alu {
+                             until_alignment -= 1;
+                         }
+                         if accu >= $bound {
+                             return false;
+                         }
                      }
                      let len_minus_stride = len - ALU_ALIGNMENT / unit_size;
                      if offset + (4 * (ALU_ALIGNMENT / unit_size)) <= len {
@@ -2127,7 +2870,17 @@ index ba8d9e3..0f9f3c1 100644
                          let len_minus_unroll = len - (4 * (ALU_ALIGNMENT / unit_size));
                          loop {
                              let unroll_accu = unsafe { *(src.add(offset) as *const usize) }
-@@ -134,12 +139,14 @@ macro_rules! by_unit_check_alu {
+                                 | unsafe {
+                                     *(src.add(offset + (ALU_ALIGNMENT / unit_size)) as *const usize)
+                                 }
+                                 | unsafe {
+                                     *(src.add(offset + (2 * (ALU_ALIGNMENT / unit_size)))
+@@ -129,22 +134,24 @@ macro_rules! by_unit_check_alu {
+                                 | unsafe {
+                                     *(src.add(offset + (3 * (ALU_ALIGNMENT / unit_size)))
+                                         as *const usize)
+                                 };
+                             if unroll_accu & $mask != 0 {
                                  return false;
                              }
                              offset += 4 * (ALU_ALIGNMENT / unit_size);
@@ -2142,7 +2895,17 @@ index ba8d9e3..0f9f3c1 100644
                          accu |= unsafe { *(src.add(offset) as *const usize) };
                          offset += ALU_ALIGNMENT / unit_size;
                      }
-@@ -189,6 +196,11 @@ macro_rules! by_unit_check_simd {
+                 }
+             }
+             for &unit in &buffer[offset..] {
+                 accu |= unit as usize;
+             }
+@@ -184,16 +191,21 @@ macro_rules! by_unit_check_simd {
+                             until_alignment -= 1;
+                         }
+                         if accu >= $bound {
+                             return false;
+                         }
                      }
                      let len_minus_stride = len - SIMD_STRIDE_SIZE / unit_size;
                      if offset + (4 * (SIMD_STRIDE_SIZE / unit_size)) <= len {
@@ -2154,7 +2917,17 @@ index ba8d9e3..0f9f3c1 100644
                          let len_minus_unroll = len - (4 * (SIMD_STRIDE_SIZE / unit_size));
                          loop {
                              let unroll_accu = unsafe { *(src.add(offset) as *const $simd_ty) }
-@@ -208,6 +220,7 @@ macro_rules! by_unit_check_simd {
+                                 | unsafe {
+                                     *(src.add(offset + (SIMD_STRIDE_SIZE / unit_size))
+                                         as *const $simd_ty)
+                                 }
+                                 | unsafe {
+@@ -203,23 +215,25 @@ macro_rules! by_unit_check_simd {
+                                 | unsafe {
+                                     *(src.add(offset + (3 * (SIMD_STRIDE_SIZE / unit_size)))
+                                         as *const $simd_ty)
+                                 };
+                             if !$func(unroll_accu) {
                                  return false;
                              }
                              offset += 4 * (SIMD_STRIDE_SIZE / unit_size);
@@ -2162,7 +2935,7 @@ index ba8d9e3..0f9f3c1 100644
                              if offset > len_minus_unroll {
                                  break;
                              }
-@@ -215,6 +228,7 @@ macro_rules! by_unit_check_simd {
+                         }
                      }
                      let mut simd_accu = $splat;
                      while offset <= len_minus_stride {
@@ -2170,7 +2943,17 @@ index ba8d9e3..0f9f3c1 100644
                          simd_accu = simd_accu | unsafe { *(src.add(offset) as *const $simd_ty) };
                          offset += SIMD_STRIDE_SIZE / unit_size;
                      }
-@@ -234,8 +248,8 @@ macro_rules! by_unit_check_simd {
+                     if !$func(simd_accu) {
+                         return false;
+                     }
+                 }
+             }
+@@ -229,18 +243,18 @@ macro_rules! by_unit_check_simd {
+             accu < $bound
+         }
+     };
+ }
+ 
  cfg_if! {
      if #[cfg(all(feature = "simd-accel", any(target_feature = "sse2", all(target_endian = "little", target_arch = "aarch64"), all(target_endian = "little", target_feature = "neon"))))] {
          use crate::simd_funcs::*;
@@ -2181,11 +2964,20 @@ index ba8d9e3..0f9f3c1 100644
  
          const SIMD_ALIGNMENT: usize = 16;
  
+         const SIMD_ALIGNMENT_MASK: usize = 15;
+ 
+         by_unit_check_simd!(is_ascii_impl, u8, u8x16::splat(0), u8x16, 0x80, simd_is_ascii);
+         by_unit_check_simd!(is_basic_latin_impl, u16, u16x8::splat(0), u16x8, 0x80, simd_is_basic_latin);
+         by_unit_check_simd!(is_utf16_latin1_impl, u16, u16x8::splat(0), u16x8, 0x100, simd_is_latin1);
 diff --git a/third_party/rust/encoding_rs/src/simd_funcs.rs b/third_party/rust/encoding_rs/src/simd_funcs.rs
-index 96feeab..5ae00e6 100644
 --- a/third_party/rust/encoding_rs/src/simd_funcs.rs
 +++ b/third_party/rust/encoding_rs/src/simd_funcs.rs
-@@ -7,55 +7,74 @@
+@@ -2,65 +2,84 @@
+ // file at the top-level directory of this distribution.
+ //
+ // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
  // option. This file may not be copied, modified, or distributed
  // except according to those terms.
  
@@ -2269,7 +3061,17 @@ index 96feeab..5ae00e6 100644
  #[allow(dead_code)]
  #[inline(always)]
  pub unsafe fn store8_aligned(ptr: *mut u16, s: u16x8) {
-@@ -100,7 +119,7 @@ pub fn simd_byte_swap(s: u16x8) -> u16x8 {
+     *(ptr as *mut u16x8) = s;
+ }
+ 
+ cfg_if! {
+     if #[cfg(all(target_feature = "sse2", target_arch = "x86_64"))] {
+@@ -95,234 +114,241 @@ cfg_if! {
+ pub fn simd_byte_swap(s: u16x8) -> u16x8 {
+     let left = s << 8;
+     let right = s >> 8;
+     left | right
+ }
  
  #[inline(always)]
  pub fn to_u16_lanes(s: u8x16) -> u16x8 {
@@ -2278,7 +3080,7 @@ index 96feeab..5ae00e6 100644
  }
  
  cfg_if! {
-@@ -108,10 +127,11 @@ cfg_if! {
+     if #[cfg(target_feature = "sse2")] {
  
          // Expose low-level mask instead of higher-level conclusion,
          // because the non-ASCII case would perform less well otherwise.
@@ -2291,7 +3093,13 @@ index 96feeab..5ae00e6 100644
              }
          }
  
-@@ -125,14 +145,16 @@ cfg_if! {
+     } else {
+ 
+     }
+ }
+ 
+ cfg_if! {
+     if #[cfg(target_feature = "sse2")] {
          #[inline(always)]
          pub fn simd_is_ascii(s: u8x16) -> bool {
              unsafe {
@@ -2310,7 +3118,8 @@ index 96feeab..5ae00e6 100644
              }
          }
      } else {
-@@ -141,7 +163,7 @@ cfg_if! {
+         #[inline(always)]
+         pub fn simd_is_ascii(s: u8x16) -> bool {
              // This optimizes better on ARM than
              // the lt formulation.
              let highest_ascii = u8x16::splat(0x7F);
@@ -2319,7 +3128,12 @@ index 96feeab..5ae00e6 100644
          }
      }
  }
-@@ -154,20 +176,21 @@ cfg_if! {
+ 
+ cfg_if! {
+     if #[cfg(target_feature = "sse2")] {
+         #[inline(always)]
+         pub fn simd_is_str_latin1(s: u8x16) -> bool {
+             if simd_is_ascii(s) {
                  return true;
              }
              let above_str_latin1 = u8x16::splat(0xC4);
@@ -2344,7 +3158,9 @@ index 96feeab..5ae00e6 100644
          }
      }
  }
-@@ -177,21 +200,23 @@ cfg_if! {
+ 
+ cfg_if! {
+     if #[cfg(target_arch = "aarch64")]{
          #[inline(always)]
          pub fn simd_is_basic_latin(s: u16x8) -> bool {
              unsafe {
@@ -2371,7 +3187,8 @@ index 96feeab..5ae00e6 100644
          }
  
          #[inline(always)]
-@@ -200,7 +225,7 @@ cfg_if! {
+         pub fn simd_is_latin1(s: u16x8) -> bool {
+             // For some reason, on SSE2 this formulation
              // seems faster in this case while the above
              // function is better the other way round...
              let highest_latin1 = u16x8::splat(0xFF);
@@ -2380,7 +3197,8 @@ index 96feeab..5ae00e6 100644
          }
      }
  }
-@@ -209,7 +234,7 @@ cfg_if! {
+ 
+ #[inline(always)]
  pub fn contains_surrogates(s: u16x8) -> bool {
      let mask = u16x8::splat(0xF800);
      let surrogate_bits = u16x8::splat(0xD800);
@@ -2389,7 +3207,7 @@ index 96feeab..5ae00e6 100644
  }
  
  cfg_if! {
-@@ -217,7 +242,8 @@ cfg_if! {
+     if #[cfg(target_arch = "aarch64")]{
          macro_rules! aarch64_return_false_if_below_hebrew {
              ($s:ident) => ({
                  unsafe {
@@ -2399,7 +3217,16 @@ index 96feeab..5ae00e6 100644
                          return false;
                      }
                  }
-@@ -234,7 +260,7 @@ cfg_if! {
+             })
+         }
+ 
+         macro_rules! non_aarch64_return_false_if_all {
+             ($s:ident) => ()
+         }
+     } else {
+         macro_rules! aarch64_return_false_if_below_hebrew {
+             ($s:ident) => ()
+         }
  
          macro_rules! non_aarch64_return_false_if_all {
              ($s:ident) => ({
@@ -2408,7 +3235,10 @@ index 96feeab..5ae00e6 100644
                      return false;
                  }
              })
-@@ -245,7 +271,7 @@ cfg_if! {
+         }
+     }
+ }
+ 
  macro_rules! in_range16x8 {
      ($s:ident, $start:expr, $end:expr) => {{
          // SIMD sub is wrapping
@@ -2417,7 +3247,13 @@ index 96feeab..5ae00e6 100644
      }};
  }
  
-@@ -259,43 +285,44 @@ pub fn is_u16x8_bidi(s: u16x8) -> bool {
+ #[inline(always)]
+ pub fn is_u16x8_bidi(s: u16x8) -> bool {
+     // We try to first quickly refute the RTLness of the vector. If that
+     // fails, we do the real RTL check, so in that case we end up wasting
+     // the work for the up-front quick checks. Even the quick-check is
+     // two-fold in order to return `false` ASAP if everything is below
+     // Hebrew.
  
      aarch64_return_false_if_below_hebrew!(s);
  
@@ -2487,7 +3323,7 @@ index 96feeab..5ae00e6 100644
  }
  
  cfg_if! {
-@@ -303,21 +330,20 @@ cfg_if! {
+     if #[cfg(target_feature = "sse2")] {
          #[inline(always)]
          pub fn simd_pack(a: u16x8, b: u16x8) -> u8x16 {
              unsafe {
@@ -2518,11 +3354,20 @@ index 96feeab..5ae00e6 100644
          }
      }
  }
+ 
+ #[cfg(test)]
+ mod tests {
+     use super::*;
+     use alloc::vec::Vec;
 diff --git a/third_party/rust/encoding_rs/src/single_byte.rs b/third_party/rust/encoding_rs/src/single_byte.rs
-index b3b6089..b7a4bf2 100644
 --- a/third_party/rust/encoding_rs/src/single_byte.rs
 +++ b/third_party/rust/encoding_rs/src/single_byte.rs
-@@ -53,6 +53,9 @@ impl SingleByteDecoder {
+@@ -48,16 +48,19 @@ impl SingleByteDecoder {
+                 CopyAsciiResult::GoOn((mut non_ascii, mut handle)) => 'middle: loop {
+                     // Start non-boilerplate
+                     //
+                     // Since the non-ASCIIness of `non_ascii` is hidden from
+                     // the optimizer, it can't figure out that it's OK to
                      // statically omit the bound check when accessing
                      // `[u16; 128]` with an index
                      // `non_ascii as usize - 0x80usize`.
@@ -2532,7 +3377,17 @@ index b3b6089..b7a4bf2 100644
                      let mapped =
                          unsafe { *(self.table.get_unchecked(non_ascii as usize - 0x80usize)) };
                      // let mapped = self.table[non_ascii as usize - 0x80usize];
-@@ -151,9 +154,12 @@ impl SingleByteDecoder {
+                     if mapped == 0u16 {
+                         return (
+                             DecoderResult::Malformed(1, 0),
+                             source.consumed(),
+                             handle.written(),
+@@ -146,82 +149,103 @@ impl SingleByteDecoder {
+         dst: &mut [u16],
+         _last: bool,
+     ) -> (DecoderResult, usize, usize) {
+         let (pending, length) = if dst.len() < src.len() {
+             (DecoderResult::OutputFull, dst.len())
          } else {
              (DecoderResult::InputEmpty, src.len())
          };
@@ -2545,7 +3400,10 @@ index b3b6089..b7a4bf2 100644
                  ascii_to_basic_latin(
                      src.as_ptr().add(converted),
                      dst.as_mut_ptr().add(converted),
-@@ -164,6 +170,12 @@ impl SingleByteDecoder {
+                     length - converted,
+                 )
+             } {
+                 None => {
                      return (pending, length, length);
                  }
                  Some((mut non_ascii, consumed)) => {
@@ -2558,7 +3416,8 @@ index b3b6089..b7a4bf2 100644
                      converted += consumed;
                      'middle: loop {
                          // `converted` doesn't count the reading of `non_ascii` yet.
-@@ -172,6 +184,9 @@ impl SingleByteDecoder {
+                         // Since the non-ASCIIness of `non_ascii` is hidden from
+                         // the optimizer, it can't figure out that it's OK to
                          // statically omit the bound check when accessing
                          // `[u16; 128]` with an index
                          // `non_ascii as usize - 0x80usize`.
@@ -2568,7 +3427,11 @@ index b3b6089..b7a4bf2 100644
                          let mapped =
                              unsafe { *(self.table.get_unchecked(non_ascii as usize - 0x80usize)) };
                          // let mapped = self.table[non_ascii as usize - 0x80usize];
-@@ -183,9 +198,10 @@ impl SingleByteDecoder {
+                         if mapped == 0u16 {
+                             return (
+                                 DecoderResult::Malformed(1, 0),
+                                 converted + 1, // +1 `for non_ascii`
+                                 converted,
                              );
                          }
                          unsafe {
@@ -2580,7 +3443,12 @@ index b3b6089..b7a4bf2 100644
                          converted += 1;
                          // Next, handle ASCII punctuation and non-ASCII without
                          // going back to ASCII acceleration. Non-ASCII scripts
-@@ -198,7 +214,10 @@ impl SingleByteDecoder {
+                         // use ASCII punctuation, so this avoid going to
+                         // acceleration just for punctuation/space and then
+                         // failing. This is a significant boost to non-ASCII
+                         // scripts.
+                         // TODO: Split out Latin converters without this part
+                         // this stuff makes Latin script-conversion slower.
                          if converted == length {
                              return (pending, length, length);
                          }
@@ -2591,7 +3459,9 @@ index b3b6089..b7a4bf2 100644
                          'innermost: loop {
                              if b > 127 {
                                  non_ascii = b;
-@@ -208,15 +227,20 @@ impl SingleByteDecoder {
+                                 continue 'middle;
+                             }
+                             // Testing on Haswell says that we should write the
                              // byte unconditionally instead of trying to unread it
                              // to make it part of the next SIMD stride.
                              unsafe {
@@ -2612,7 +3482,17 @@ index b3b6089..b7a4bf2 100644
                                  continue 'innermost;
                              }
                              // We've got markup or ASCII text
-@@ -234,6 +258,8 @@ impl SingleByteDecoder {
+                             continue 'outermost;
+                         }
+                     }
+                 }
+             }
+@@ -229,16 +253,18 @@ impl SingleByteDecoder {
+     }
+ 
+     pub fn latin1_byte_compatible_up_to(&self, buffer: &[u8]) -> usize {
+         let mut bytes = buffer;
+         let mut total = 0;
          loop {
              if let Some((non_ascii, offset)) = validate_ascii(bytes) {
                  total += offset;
@@ -2621,7 +3501,17 @@ index b3b6089..b7a4bf2 100644
                  let mapped = unsafe { *(self.table.get_unchecked(non_ascii as usize - 0x80usize)) };
                  if mapped != u16::from(non_ascii) {
                      return total;
-@@ -384,9 +410,12 @@ impl SingleByteEncoder {
+                 }
+                 total += 1;
+                 bytes = &bytes[offset + 1..];
+             } else {
+                 return total;
+@@ -379,64 +405,89 @@ impl SingleByteEncoder {
+         dst: &mut [u8],
+         _last: bool,
+     ) -> (EncoderResult, usize, usize) {
+         let (pending, length) = if dst.len() < src.len() {
+             (EncoderResult::OutputFull, dst.len())
          } else {
              (EncoderResult::InputEmpty, src.len())
          };
@@ -2634,7 +3524,10 @@ index b3b6089..b7a4bf2 100644
                  basic_latin_to_ascii(
                      src.as_ptr().add(converted),
                      dst.as_mut_ptr().add(converted),
-@@ -397,15 +426,23 @@ impl SingleByteEncoder {
+                     length - converted,
+                 )
+             } {
+                 None => {
                      return (pending, length, length);
                  }
                  Some((mut non_ascii, consumed)) => {
@@ -2658,7 +3551,15 @@ index b3b6089..b7a4bf2 100644
                              }
                              None => {
                                  // At this point, we need to know if we
-@@ -421,6 +458,8 @@ impl SingleByteEncoder {
+                                 // have a surrogate.
+                                 let high_bits = non_ascii & 0xFC00u16;
+                                 if high_bits == 0xD800u16 {
+                                     // high surrogate
+                                     if converted + 1 == length {
+                                         // End of buffer. This surrogate is unpaired.
+                                         return (
+                                             EncoderResult::Unmappable('\u{FFFD}'),
+                                             converted + 1, // +1 `for non_ascii`
                                              converted,
                                          );
                                      }
@@ -2667,7 +3568,11 @@ index b3b6089..b7a4bf2 100644
                                      let second =
                                          u32::from(unsafe { *src.get_unchecked(converted + 1) });
                                      if second & 0xFC00u32 != 0xDC00u32 {
-@@ -432,6 +471,18 @@ impl SingleByteEncoder {
+                                         return (
+                                             EncoderResult::Unmappable('\u{FFFD}'),
+                                             converted + 1, // +1 `for non_ascii`
+                                             converted,
+                                         );
                                      }
                                      // The next code unit is a low surrogate.
                                      let astral: char = unsafe {
@@ -2686,7 +3591,17 @@ index b3b6089..b7a4bf2 100644
                                          ::core::char::from_u32_unchecked(
                                              (u32::from(non_ascii) << 10) + second
                                                  - (((0xD800u32 << 10) - 0x1_0000u32) + 0xDC00u32),
-@@ -456,6 +507,7 @@ impl SingleByteEncoder {
+                                         )
+                                     };
+                                     return (
+                                         EncoderResult::Unmappable(astral),
+                                         converted + 2, // +2 `for non_ascii` and `second`
+@@ -451,52 +502,63 @@ impl SingleByteEncoder {
+                                         converted,
+                                     );
+                                 }
+                                 return (
+                                     EncoderResult::unmappable_from_bmp(non_ascii),
                                      converted + 1, // +1 `for non_ascii`
                                      converted,
                                  );
@@ -2694,7 +3609,13 @@ index b3b6089..b7a4bf2 100644
                              }
                          }
                          // Next, handle ASCII punctuation and non-ASCII without
-@@ -469,8 +521,12 @@ impl SingleByteEncoder {
+                         // going back to ASCII acceleration. Non-ASCII scripts
+                         // use ASCII punctuation, so this avoid going to
+                         // acceleration just for punctuation/space and then
+                         // failing. This is a significant boost to non-ASCII
+                         // scripts.
+                         // TODO: Split out Latin converters without this part
+                         // this stuff makes Latin script-conversion slower.
                          if converted == length {
                              return (pending, length, length);
                          }
@@ -2707,7 +3628,8 @@ index b3b6089..b7a4bf2 100644
                              if unit > 127 {
                                  non_ascii = unit;
                                  continue 'middle;
-@@ -479,19 +535,25 @@ impl SingleByteEncoder {
+                             }
+                             // Testing on Haswell says that we should write the
                              // byte unconditionally instead of trying to unread it
                              // to make it part of the next SIMD stride.
                              unsafe {
@@ -2733,11 +3655,20 @@ index b3b6089..b7a4bf2 100644
                          }
                      }
                  }
+             }
+         }
+     }
+ }
+ 
 diff --git a/third_party/rust/encoding_rs/src/x_user_defined.rs b/third_party/rust/encoding_rs/src/x_user_defined.rs
-index 103c9af..7af7d5e 100644
 --- a/third_party/rust/encoding_rs/src/x_user_defined.rs
 +++ b/third_party/rust/encoding_rs/src/x_user_defined.rs
-@@ -14,12 +14,13 @@ use crate::variant::*;
+@@ -9,22 +9,23 @@
+ 
+ use super::*;
+ use crate::handles::*;
+ use crate::variant::*;
+ 
  cfg_if! {
      if #[cfg(feature = "simd-accel")] {
          use simd_funcs::*;
@@ -2753,7 +3684,17 @@ index 103c9af..7af7d5e 100644
      } else {
      }
  }
-@@ -116,10 +117,15 @@ impl UserDefinedDecoder {
+ 
+ pub struct UserDefinedDecoder;
+ 
+ impl UserDefinedDecoder {
+     pub fn new() -> VariantDecoder {
+@@ -111,20 +112,25 @@ impl UserDefinedDecoder {
+         } else {
+             (DecoderResult::InputEmpty, src.len())
+         };
+         // Not bothering with alignment
+         let tail_start = length & !0xF;
          let simd_iterations = length >> 4;
          let src_ptr = src.as_ptr();
          let dst_ptr = dst.as_mut_ptr();
@@ -2769,9 +3710,13 @@ index 103c9af..7af7d5e 100644
                  store8_unaligned(dst_ptr.add(i * 16), shift_upper(first));
                  store8_unaligned(dst_ptr.add((i * 16) + 8), shift_upper(second));
              }
+         }
+         let src_tail = &src[tail_start..length];
+         let dst_tail = &mut dst[tail_start..length];
+         src_tail
+             .iter()
 diff --git a/third_party/rust/packed_simd/.appveyor.yml b/third_party/rust/packed_simd/.appveyor.yml
 deleted file mode 100644
-index 0388cee..0000000
 --- a/third_party/rust/packed_simd/.appveyor.yml
 +++ /dev/null
 @@ -1,59 +0,0 @@
@@ -2836,15 +3781,13 @@ index 0388cee..0000000
 -test_script: bash -c "ci/run.sh"
 diff --git a/third_party/rust/packed_simd/.cargo-checksum.json b/third_party/rust/packed_simd/.cargo-checksum.json
 deleted file mode 100644
-index 870eeda..0000000
 --- a/third_party/rust/packed_simd/.cargo-checksum.json
 +++ /dev/null
-@@ -1 +0,0 @@
+@@ -1,1 +0,0 @@
 -{"files":{".appveyor.yml":"f1ed01850e0d725f9498f52a1a63ddf40702ad6e0bf5b2d7c4c04d76e96794a3",".github/workflows/benchmarks.yml":"d049f016dc53830a3fcc735833eca168df2e491f33b6b44ce7e4d5d1dd453854",".github/workflows/ci.yml":"170a2074add57ddc8f88b780149e4930162c6ee4718add4369dca8e3fd6c022a",".github/workflows/docs.yml":"86f7eb652c900624e4deb76320cd92175db1fa7295a76f28f30336ff0fad1604",".github/workflows/run-ci-script.yml":"d847be293f9ec17038e450652b1eb7bdc20b805c18c5dbab34d1d9ff7a9c8940",".travis.yml":"30a61a5ec53355fc1f3585e1690280308c2b7961701abc11e8389b235b647178","Cargo.toml":"02151c415f267a6aeb8651158472744d71e1d9da8883dd20be25731a42e520f4","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"6485b8ed310d3f0340bf1ad1f47645069ce4069dcc6bb46c7d5c6faf41de1fdb","README.md":"c4ac7027a9ab7d7858aa8957d7454dbfcdbb81e605b6a171f05310cc3cad3762","bors.toml":"dee881dc69b9b7834e4eba5d95c3ed5a416d4628815a167d6a22d4cb4fb064b8","build.rs":"019ed29c43989782d8eec3a961654cfc172d7a7898da4eca8f654700af7e1988","ci/all.sh":"2ae6b2445b4db83833e40b37efd0016c6b9879ee988b9b3ef94db5439a3e1606","ci/android-install-ndk.sh":"bdcf93ba9043ac1184e2c504a3d40c47c6c1601d882e0f0a27a8eb56fbabcb5f","ci/android-install-sdk.sh":"3490432022c5c8f5a115c084f7a9aca1626f96c0c87ffb62019228c4346b47e4","ci/android-sysimage.sh":"ebf4e5daa1f0fe1b2092b79f0f3f161c4c4275cb744e52352c4d81ab451e4c5a","ci/benchmark.sh":"b61d19ef6b90deba8fb79dee74c8b062d94844676293da346da87bb78a9a49a4","ci/deploy_and_run_on_ios_simulator.rs":"ec8ecf82d92072676aa47f0d1a3d021b60a7ae3531153ef12d2ff4541fc294dc","ci/docker/aarch64-linux-android/Dockerfile":"ace2e7d33c87bc0f6d3962a4a3408c04557646f7f51ab99cfbf574906796b016","ci/docker/aarch64-unknown-linux-gnu/Dockerfile":"da88c0d50f16dc08448c7fdf1fa5ed2cbe576acf9e7dd85b5b818621b2a8c702","ci/docker/arm-unknown-linux-gnueabi/Dockerfile":"bb5f8ae890707c128652290ffc544447643bf12037ddd73c6ad6989f848cb380","ci/docker/arm-unknown-linux-gnueabihf/Dockerfile":"1afaefcbc05b740859acd4e067bc92439be6bcbe8f2e9678474fb434bcd398d9","ci/docker/armv7-linux-androideabi/Dockerfile":"370e55d3330a413a3ccf677b3afb3e0ef9018a5fab263faa97ae8ac017fc2286","ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile":"8282ea707a94109beed47a57574755e2d58401735904a03f85fb64c578c53b4f","ci/docker/i586-unknown-linux-gnu/Dockerfile":"49792922269f371bd29da4727e9085101b27be67a6b97755d0196c63317f7abb","ci/docker/i686-unknown-linux-gnu/Dockerfile":"49792922269f371bd29da4727e9085101b27be67a6b97755d0196c63317f7abb","ci/docker/mips-unknown-linux-gnu/Dockerfile":"b2ebc25797612c4f8395fe9d407725156044955bfbcf442036b7f55b43a5f9da","ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile":"b0c1692ac65bc56dd30494b1993d8e929c48cc9c4b92029b7c7592af6d4f9220","ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile":"4e9249c179300138141d0b2b7401b11897f64aed69f541f078c1db4594df2827","ci/docker/mipsel-unknown-linux-musl/Dockerfile":"3164c52b0dcbb01afa78292b15b5c43503ccf0491cf6eb801ec2bf22ae274e52","ci/docker/powerpc-unknown-linux-gnu/Dockerfile":"ae8274309928620a5dd232a46264e05399bb746288ebee3843a71c4162208cc3","ci/docker/powerpc64-unknown-linux-gnu/Dockerfile":"ba5fbc4bf3bb91cd50b407248da31225681efc8f2be7618f4a0ab1219b389508","ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile":"53f97f8b9b5aca7534b9bf9ea48f35175052cd2a560a107e01ad270731c032fc","ci/docker/s390x-unknown-linux-gnu/Dockerfile":"89f5421cf06d817ae94092987e914472ef384ad2d1fff2735be3d8786ba11214","ci/docker/sparc64-unknown-linux-gnu/Dockerfile":"83eba19576486f9d10d7c037d669d72b31a65565a479f30b22aab36aaa2ff8dc","ci/docker/thumbv7neon-linux-androideabi/Dockerfile":"c2decd5591bd7a09378901bef629cd944acf052eb55e4f35b79eb9cb4d62246a","ci/docker/thumbv7neon-unknown-linux-gnueabihf/Dockerfile":"51955a8bf3c4d440f47382af6f5426ebff94ab01a04da36175babda9a057740f","ci/docker/wasm32-unknown-unknown/Dockerfile":"b982b421c70db476900df5b60e19ef8815e6c7dae22687225002780cab7b0a76","ci/docker/x86_64-linux-android/Dockerfile":"a17ebdb186ce2dd6b62100b5a439e05a1ab9adab113e2508843e121aaea52992","ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile":"44b6203d9290bfdc53d81219f0937e1110847a23dd982ec8c4de388354f01536","ci/docker/x86_64-unknown-linux-gnu/Dockerfile":"7f4e3ca5fa288ea70edb4d1f75309708cd30b192e2e4444e61c4d5b3b58f89cf","ci/dox.sh":"434e9611c52e389312d2b03564adf09429f10cc76fe66a8644adb104903b87b7","ci/linux-s390x.sh":"d6b732d7795b4ba131326aff893bca6228a7d2eb0e9402f135705413dbbe0dce","ci/linux-sparc64.sh":"c92966838b1ab7ad3b7a344833ee726aba6b647cf5952e56f0ad1ba420b13325","ci/lld-shim.rs":"3d7f71ec23a49e2b67f694a0168786f9a954dda15f5a138815d966643fd3fcc3","ci/max_line_width.sh":"0a1518bba4c9ecaa55694cb2e9930d0e19c265baabf73143f17f9cf285aaa5bb","ci/run-docker.sh":"92e036390ad9b0d16f109579df1b5ced2e72e9afea40c7d011400ebd3a2a90de","ci/run.sh":"9afabc961e0ee83b87201f3fd554c19e5b0c36f3a95d013595e276c9882dd0a4","ci/run_examples.sh":"d1a23c6c35374a0678ba5114b9b8fefd8be0a79e774872a8bf0898d1baca18d0","ci/runtest-android.rs":"145a8e9799a5223975061fe7e586ade5669ee4877a7d7a4cf6b4ab48e8e36c7c","ci/setup_benchmarks.sh":"fae3960023f6f3d1388cd2ad22fdbab4b075f1f29dd4292d7994a20783beb6cf","ci/test-runner-linux":"c8aa6025cff5306f4f31d0c61dc5f9d4dd5a1d189ab613ef8d4c367c694d9ccd","contributing.md":"2d2629310ad4d464c482bdbb5819f0d6ce223c576aeef2cdce6a1f6857085ea5","perf-guide/.gitignore":"fe82c7da551079d832cf74200b0b359b4df9828cb4a0416fa7384f07a2ae6a13","perf-guide/book.toml":"115a98284126c6b180178b44713314cc494f08a71662ee2ce15cf67f17a51064","perf-guide/src/SUMMARY.md":"3e03bffc991fdc2050f3d51842d72d9d21ea6abab56a3baf3b2d5973a78b89e1","perf-guide/src/ascii.css":"29afb08833b2fe2250f0412e1fa1161a2432a0820a14953c87124407417c741a","perf-guide/src/bound_checks.md":"5e4991ff58a183ef0cd9fdc1feb4cd12d083b44bdf87393bbb0927808ef3ce7d","perf-guide/src/float-math/approx.md":"8c09032fa2d795a0c5db1775826c850d28eb2627846d0965c60ee72de63735ad","perf-guide/src/float-math/fma.md":"311076ba4b741d604a82e74b83a8d7e8c318fcbd7f64c4392d1cf5af95c60243","perf-guide/src/float-math/fp.md":"04153e775ab6e4f0d7837bcc515230d327b04edfa34c84ce9c9e10ebaeef2be8","perf-guide/src/float-math/svml.md":"0798873b8eedaeda5fed62dc91645b57c20775a02d3cd74d8bd06958f1516506","perf-guide/src/introduction.md":"9f5a19e9e6751f25d2daad39891a0cc600974527ec4c8305843f9618910671bd","perf-guide/src/prof/linux.md":"447731eb5de7d69166728fdbc5ecb0c0c9db678ea493b45a592d67dd002184c0","perf-guide/src/prof/mca.md":"f56d54f3d20e7aa4d32052186e8237b03d65971eb5d112802b442570ff11d344","perf-guide/src/prof/profiling.md":"8a650c0fd6ede0964789bb6577557eeef1d8226a896788602ce61528e260e43c","perf-guide/src/target-feature/attribute.md":"615f88dca0a707b6c416fa605435dd6e1fb5361cc639429cbf68cd87624bd78b","perf-guide/src/target-feature/features.md":"17077760ff24c006b606dd21889c53d87228f4311f3ba3a574f9afdeacd86165","perf-guide/src/target-feature/inlining.md":"7ed1d7068d8173a00d84c16cfe5871cd68b9f04f8d0cca2d01ebc84957ebf2f6","perf-guide/src/target-feature/practice.md":"c4b371842e0086df178488fec97f20def8f0c62ee588bcd25fd948b9b1fa227e","perf-guide/src/target-feature/runtime.md":"835425f5ee597fb3e51d36e725a81ebee29f4561231d19563cd4da81dbb1cfcb","perf-guide/src/target-feature/rustflags.md":"01197acf6f0adec8db32b8591811f69cecb6555a2b05dc5d5ec27d0e3f7b065e","perf-guide/src/vert-hor-ops.md":"c6211c0ee91e60552ec592d89d9d957eedc21dee3cbd89e1ad6765ea06a27471","rustfmt.toml":"d99a43f3f8ef9e425cf01c333fba9f0051f888f5d87ab4e8f63c2f7d0fe6620f","src/api.rs":"bb1795e9657a8298d37d2349b45443f08e9e455399ad4b727018600728478c10","src/api/bit_manip.rs":"27f3097fc0a11e3c4107049d9779e680dcd67407a066704008a6b9c4fd529e05","src/api/bitmask.rs":"058ebc38a2e0363f07a441d3e9a4775aaec57ccb170a0e5d5efa5dc4743ab07b","src/api/cast.rs":"03b94a3d316ac7b7be7068810044911e965e889a0ace7bae762749ca74a92747","src/api/cast/macros.rs":"b0a14d0c83ad2ebb7a275180f6d9e3f2bc312ba57a7d3d6c39fad4e0f20f9408","src/api/cast/v128.rs":"edd0994efac4379dff26e178423a52dbb3ffeb38b1fc97cae975d744c00b4fb6","src/api/cast/v16.rs":"96bd98c2d21b0663abe6c0ab33005b1fa693f3db7ee6795351391343863484da","src/api/cast/v256.rs":"8c31fe91f5e78ef737dfba6979cc1240210cb094a89d284fe459bf8a991ca24b","src/api/cast/v32.rs":"a99a79dd84d2a5e6adf9db98705675915bd03fd1287d489c7fe38e84d7e4a086","src/api/cast/v512.rs":"c0dd526f41ed7b8a71c3743d91267554ec0a0c75834ccc2e3ecb0ef3004af642","src/api/cast/v64.rs":"6572fdba2a1241a6cd666d3f0cce3306cd2cb7e5e236172e59d5d4351c8a88af","src/api/cmp.rs":"357c3a2a09c6d4611c32dd7fa95be2fae933d513e229026ec9b44451a77b884e","src/api/cmp/eq.rs":"60f70f355bae4cb5b17db53204cacc3890f70670611c17df638d4c04f7cc8075","src/api/cmp/ord.rs":"589f7234761c294fa5df8f525bc4acd5a47cdb602207d524a0d4e19804cd9695","src/api/cmp/partial_eq.rs":"902ccb8aa01fd5738b30ba0b712669c21d4801958907e03bad23432c7dba0198","src/api/cmp/partial_ord.rs":"9db0c37d7434cdfc62d8d66912e972fa3d8c115ab2af051a6f45e414bd3e4f1c","src/api/cmp/vertical.rs":"de3d62f38eba817299aa16f1e1939954c9a447e316509397465c2830852ba053","src/api/default.rs":"67bf21c134127d12a7028c8b88a57f0ceee8ccbd74976da8ca74eb9f16a174d5","src/api/fmt.rs":"67fb804bb86b6cd77cf8cd492b5733ce437071b66fe3297278b8a6552c325dda","src/api/fmt/binary.rs":"02b2b287f7404f8a983813cf70c87108c8da3835578b63ab303116885f609413","src/api/fmt/debug.rs":"56e1c3bdc092747344fffaafff9da7163ee7827857f6fb7cb1c9923eca4f6fa0","src/api/fmt/lower_hex.rs":"558fd592f7f485712fb051509cecc7174a21e6bf62e5ce64766e75afc97bb8e1","src/api/fmt/octal.rs":"3b2e70877a4f368c7704f8e254236c014c365c74d93371c1feb5f030e6c66422","src/api/fmt/upper_hex.rs":"2a442f666bc80e22d41f903f881238fe114dd49344c3ed69849250e853cafc5d","src/api/from.rs":"2e599d8329cb05eaf06224cc441355c4b7b51254fc19256619333be8c149d444","src/api/from/from_array.rs":"5d2cc700568376bf6ee1fe5e406da3bc2d488ff155644bf73d06a1349b73fc53","src/api/from/from_vector.rs":"9764371aa9e6005aace74dea14f59e5611a095b7cf42707940924749282c52f0","src/api/hash.rs":"5076ece87969592c876486f5b1ea8affbeaec379d1a14a30859e0aa5592019de","src/api/into_bits.rs":"8f8011627250e23e66b5c0ca641afb079d8232674bb1354140b536bdbea63e55","src/api/into_bits/arch_specific.rs":"e7445021f3908326bfee758835e5fc5ad56aa1baa77fc1c58abe4350c66c670a","src/api/into_bits/macros.rs":"bb4fe99be2af6a21d805efab44c8e4e61a7b2adb42a65504a0cf26d13efdadcd","src/api/into_bits/v128.rs":"145a44922b09a5ca5b62d88a461d327d399a997a15db4b11d7b17e554a9fa4c0","src/api/into_bits/v16.rs":"f4f4f61ba88aa51b158ec56ca3dce234349aea0daf2b3029a14ab5125d1e41e5","src/api/into_bits/v256.rs":"8cea9c5d9809f11323cb7cdc53b83df593fd17caf926251e412ae9777bed547f","src/api/into_bits/v32.rs":"905ba683d342fa32f4202b80bb46530807bd0a5b588f6c2e8c9f475223c47775","src/api/into_bits/v512.rs":"e25afa1fbf088a5d58e7d75d197b6cd4c56637ea28542ba18e46a451f29d04e7","src/api/into_bits/v64.rs":"d6238022ccff7b92e55b3f6017fc269acb6f36330a6d7e8fb389853a0f1b6478","src/api/math.rs":"8b2a2fc651917a850539f993aa0b9e5bf4da67b11685285b8de8cdca311719ec","src/api/math/float.rs":"61d2794d68262a1090ae473bd30793b5f65cf732f32a6694a3af2ce5d9225616","src/api/math/float/abs.rs":"5b6b2701e2e11135b7ce58a05052ea8120e10e4702c95d046b9d21b827b26bf8","src/api/math/float/consts.rs":"6302c9261da4291d144d5bb53493cdd073498feb40955fb6860ea3c4d06c978a","src/api/math/float/cos.rs":"4c2dd7173728ef189314f1576c9486e03be21b7da98843b2f9011282a7979e31","src/api/math/float/exp.rs":"7c6d5f1e304f498a01cfa23b92380c815d7da0ad94eae3483783bc377d287eef","src/api/math/float/ln.rs":"54c7583f3df793b39ff57534fade27b41bb992439e5dc178252f5ca3190a3e54","src/api/math/float/mul_add.rs":"62cac77660d20159276d4c9ef066eb90c81cbddb808e8e157182c607625ad2eb","src/api/math/float/mul_adde.rs":"bae056ee9f3a70df39ec3c3b2f6437c65303888a7b843ef1a5bcf1f5aca0e602","src/api/math/float/powf.rs":"9ddb938984b36d39d82a82f862f80df8f7fb013f1d222d45698d41d88472f568","src/api/math/float/recpre.rs":"589225794ff1dbf31158dff660e6d4509ecc8befbb57c633900dea5ac0b840d6","src/api/math/float/rsqrte.rs":"a32abdcc318d7ccc8448231f54d75b884b7cbeb03a7d595713ab6243036f4dbf","src/api/math/float/sin.rs":"cbd3622b7df74f19691743001c8cf747a201f8977ad90542fee915f37dcd1e49","src/api/math/float/sqrt.rs":"0c66d5d63fb08e4d99c6b82a8828e41173aff1ac9fa1a2764a11fac217ccf2ac","src/api/math/float/sqrte.rs":"731e1c9f321b662accdd27dacb3aac2e8043b7aecb2f2161dde733bd9f025362","src/api/minimal.rs":"1f22bcc528555444e76de569ec0ae2029b9ae9d04805efeafa93369c8098036b","src/api/minimal/iuf.rs":"819cff26d3e196f807645bcc1d79eb27d9f175edb89910f2274d52a1e913cd11","src/api/minimal/mask.rs":"0cae10ae1fc65f5070e686c0c79bfba27b86b33d6c399367bd4848fb367dcec4","src/api/minimal/ptr.rs":"f74d7a4925d7209faebc26ea8315259cb2c08ec65789a70869e595649a9bc39a","src/api/ops.rs":"3e273b277a0f3019d42c3c59ca94a5afd4885d5ae6d2182e5089bbeec9de42ee","src/api/ops/scalar_arithmetic.rs":"d2d5ad897a59dd0787544f927e0e7ca4072c3e58b0f4a2324083312b0d5a21d7","src/api/ops/scalar_bitwise.rs":"482204e459ca6be79568e1c9f70adbe2d2151412ddf122fb2161be8ebb51c40c","src/api/ops/scalar_mask_bitwise.rs":"c250f52042e37b22d57256c80d4604104cfd2fbe2a2e127c676267270ca5d350","src/api/ops/scalar_shifts.rs":"c4773d435c3f9da4454327e6fbb2b5b41a1c0ebb1cca7372e69dc7a344a1b6e4","src/api/ops/vector_arithmetic.rs":"ddca15d09ddeef502c2ed66117a62300ca65d87e959e8b622d767bdf1c307910","src/api/ops/vector_bitwise.rs":"b3968f7005b649edcc22a54e2379b14d5ee19045f2e784029805781ae043b5ee","src/api/ops/vector_float_min_max.rs":"76bf8cb607e2c442923c1da1061a6b80d742d607408033c2a3761161114cf2a0","src/api/ops/vector_int_min_max.rs":"a378789c6ff9b32a51fbd0a97ffd36ed102cd1fe6a067d2b02017c1df342def6","src/api/ops/vector_mask_bitwise.rs":"5052d18517d765415d40327e6e8e55a312daaca0a5e2aec959bfa54b1675f9c8","src/api/ops/vector_neg.rs":"5c62f6b0221983cdbd23cd0a3af3672e6ba1255f0dfe8b19aae6fbd6503e231b","src/api/ops/vector_rotates.rs":"6c3f761d9d551f6365a8a95539ceace4b1a02e0b12d144f34ed68db94e88cff4","src/api/ops/vector_shifts.rs":"e510be14127c0ffd58a2573a39701da3557d66bedec09837ac8bbd44d579da00","src/api/ptr.rs":"8a793251bed6130dcfb2f1519ceaa18b751bbb15875928d0fb6deb5a5e07523a","src/api/ptr/gather_scatter.rs":"3d614f9d5b4ca201a9f7e46af4405e1d2c28ecee1620297c23b52e37b92cc0ea","src/api/reductions.rs":"ae5baca81352ecd44526d6c30c0a1feeda475ec73ddd3c3ec6b14e944e5448ee","src/api/reductions/bitwise.rs":"8bf910ae226188bd15fc7e125f058cd2566b6186fcd0cd8fd020f352c39ce139","src/api/reductions/float_arithmetic.rs":"47a5679896db2cbb56c31372fe42143da015b6beae7db5d2f3a0309ddf427ae1","src/api/reductions/integer_arithmetic.rs":"c2df3cf7493cca4174f2c65aea422a3d20d8a23af03f8d57cef72c19fee8f20d","src/api/reductions/mask.rs":"db83327a950e33a317f37fd33ca4e20c347fb415975ec024f3e23da8509425af","src/api/reductions/min_max.rs":"6af8c9aa45c69961b1b6fc205395f4767d4421869fb105fb3d563c5605fc13cd","src/api/select.rs":"6b07e7e8026df561f7307221a896f0fbb272536f41b9109040ac094c24c69331","src/api/shuffle.rs":"be7faff9b59654926df12897b2f98a4baa7d6acf2af1aaf93d388ba6e96f83ec","src/api/shuffle1_dyn.rs":"bfea5a91905b31444e9ef7ca6eddb7a9606b7e22d3f71bb842eb2795a0346620","src/api/slice.rs":"ee87484e8af329547b9a5d4f2a69e8bed6ea10bbd96270d706083843d4eea2ac","src/api/slice/from_slice.rs":"3735363000737104a8fc5f394ad8c31ec14e885952bd57647dd2a84001aee0a6","src/api/slice/write_to_slice.rs":"79d09c64d00724783c77c42e4583eeec97b18db94cf2ae146b564c3f85cfefd6","src/api/swap_bytes.rs":"05b4262eaade2f63e6cd3b780c19a03aecd2459d4cc4360051fc088887179a6e","src/codegen.rs":"db4f232fb9f5728db310b87dc8c4733be48afacab1053798c06106bef9a42b05","src/codegen/bit_manip.rs":"525ea6ff7ad1e043b6f6136992166f1803ed5563b7f6fc292c1c40257d20e264","src/codegen/llvm.rs":"12e748b4928c3be6cc12b4165c3041a3d0efccf6195338ecd3d88b8fdb0bbcc7","src/codegen/math.rs":"dfcf02ad34e2fdfe22c3f1cc2822001cc895e65031b4d06e585e5047839febb7","src/codegen/math/float.rs":"2c1cbce155bc527ce34d472c0fef6bc3dadb79cd7a357dd7aa5b1ebeb1d77a13","src/codegen/math/float/abs.rs":"d5aaadcf540bdb9b4264dca6471a255fd7bf509e763bef0239c0144a68466fea","src/codegen/math/float/cos.rs":"17f28d2900c852dca221fa9c92a9cd5fe7fd2df8d427bbc60216c749b2be013d","src/codegen/math/float/cos_pi.rs":"dbaf9f443f9846a491d4ec52210a7b5835dd593b03366e3135b05c37d70f9d6c","src/codegen/math/float/exp.rs":"d300058a4bcc7ae7976f216f81902cd73a9e603ad63880dff3bbc866c27a9f37","src/codegen/math/float/ln.rs":"c851e211e43f8256093ba75b03ae0c307c9962ee66d94f09b4dd80068190cbdf","src/codegen/math/float/macros.rs":"fc9924869ed85e4795983af228cacf23158f4f35919adce16c920ad4a3f0a009","src/codegen/math/float/mul_add.rs":"041a5b69d5991d93ef795351b17560c10faf80b78fd26ad7df42a239b32cf9de","src/codegen/math/float/mul_adde.rs":"d71d5f0f3333b62a7439b823cb7adf5340ea1555ce820fb4a3f4cb922f73f5f5","src/codegen/math/float/powf.rs":"9742c3877f1a5509ca5c9492a40884b6579ba6dd11c26b7112e63f70666b395d","src/codegen/math/float/sin.rs":"0e9868d35531566509f3a01d85d5253045eb4afa8525d8407dcc1f5f33c56036","src/codegen/math/float/sin_cos_pi.rs":"8e6b6142d7dd240cdb36669722e82ab9810a2261e86e659f7d97a942ad8b1258","src/codegen/math/float/sin_pi.rs":"bb6d39db8f921e03a301fc5206ac1a61a97def8a2cb83b87ccf189f3fc48d548","src/codegen/math/float/sqrt.rs":"e6ebb0c5f428efad1f672b9a8fe4e58534dbf1ea5a8fe092ce5ce76b52fe89cb","src/codegen/math/float/sqrte.rs":"23acfaea38d0e081a6d9021c1094e813d0cfd12c58c1eca9662aade5e625d51c","src/codegen/pointer_sized_int.rs":"6ca13c214b6cf7e0929dbe18e96a16fc0bb7d8799608df29c4c8115490f99e01","src/codegen/reductions.rs":"8eb18ebac76985d2aa30262a2edd8cb004230b511a765d657525f677a585c12c","src/codegen/reductions/mask.rs":"e67f35a1f4d156a4894a2d6ea5a935b4d898cf70eefb2715f5c1cc165e776c11","src/codegen/reductions/mask/aarch64.rs":"84b101c17cad1ede4eb6d38cada0ac7da239dba8cea3badd3829b967e558431f","src/codegen/reductions/mask/arm.rs":"aaa07129bd078ae7e677cf8b8e67ec9f30536606a0c7ed1baaa18fd1793bb218","src/codegen/reductions/mask/fallback.rs":"3eb9319d2c7cf19216b607b8459612c4e027b643cf11b036937d36896bf76786","src/codegen/reductions/mask/fallback_impl.rs":"76547f396e55ef403327c77c314cf8db8c7a5c9b9819bfb925abeacf130249e5","src/codegen/reductions/mask/x86.rs":"36dcd8af4ab99730a078ed113d3955f74eb1a2876e2e6d9f224e0ff462c216d1","src/codegen/reductions/mask/x86/avx.rs":"3a40868b38c86e35aefb96d7578de6322efe89d8135e0366359b54ddd06f861a","src/codegen/reductions/mask/x86/avx2.rs":"677aed3f056285285daa3adff8bc65e739630b4424defa6d9665e160f027507e","src/codegen/reductions/mask/x86/sse.rs":"8522f6ed03f6c32dd577d4298df477c08aeaaa38563706f29096e1911ed731f2","src/codegen/reductions/mask/x86/sse2.rs":"54ec56e49b0c6841eccb719e4f310d65fe767c04136b2ec20bd8b9d7d9897b9e","src/codegen/shuffle.rs":"1ec2930f4e1acc43ac30b518af298d466a79e9e75734a51c380b7810efd1a27f","src/codegen/shuffle1_dyn.rs":"3f13ca1597378758d05106bf5ff3715eee531f3cb6d88f48b9182bd6c9386b51","src/codegen/swap_bytes.rs":"c67c86e91ca3fc77539e0efcea081a3c62548cccf503963ae408f2e86f4e6a21","src/codegen/v128.rs":"94226b31ec403d18d9d2fe06713f147c9c79e9b5f9105089088266313f843185","src/codegen/v16.rs":"ddec4ffb66b6f7aaffb9a1780c5ddba82557abd74f45073d335047e04cf74924","src/codegen/v256.rs":"6b63917f0444118d6b1595bff2045e59b97c4d24012bd575f69f1f0efc5a0241","src/codegen/v32.rs":"3477b3c5540aed86e61e2f5807dd31db947413cec9181c587d93ed6ec74f0eba","src/codegen/v512.rs":"5854f99d3aabc4cd42b28a20d9ce447756dc2ba024a409a69b6a8ae1f1842fc5","src/codegen/v64.rs":"e9e89caebfe63d10c0cbca61e4dfdba3b7e02ee0989170f80beed23237ddd950","src/codegen/vPtr.rs":"f0753b405cdc865bdf8e82c6505f299ea1f96136239ebbaf7f9ce93d310764b8","src/codegen/vSize.rs":"c89f5fdeb28ac4c8272ed1816fce03d9d95308cc32bb2533bd8b20cd5ac102ac","src/lib.rs":"05048c6a85ec65cf902d9dd8f757a3f76392b703a6794ea71f0d41500a89f78f","src/masks.rs":"70fc0abe4c2907ce2a491c574e1cfb9f3423385da2e1a923a48c9c13f8ba6ed8","src/sealed.rs":"ae7fdeaf5d84cd7710ed730ca72ca7eaba93df6cb0acb183e5c0a7327acf197f","src/testing.rs":"896669c08d8c801448a4d2fadc9d633eda0fbe879d229997e2a182e31278e469","src/testing/macros.rs":"403bbc5ecb7c786fe36156df302d0c07a8122408dbb15f7474d7682224ba1106","src/testing/utils.rs":"41912a92266dfe884647fc035e4242fd746100df8e839808ae0397af3759a3c8","src/v128.rs":"16cf9a8e7156b899ee9b9cd3f2dba9d13ec63289bea8c3ee9ae2e43ad9510288","src/v16.rs":"cb6465cf1e00bf530183af1819b9fe3d7eec978f8765d5e85d9b58a39a4b4045","src/v256.rs":"fe235017da18c7f3c361831c60e3173ad304d8ea1e95d64ebebc79da2d708511","src/v32.rs":"145d347855bac59b2de6508f9e594654e6c330423af9edc0e2ac8f4d1abdf45e","src/v512.rs":"f372f277f3e62eb5c945bb1c460333fdb17b6974fcc876633788ff53bded9599","src/v64.rs":"0b8079881b71575e3414be0b7f8f7eaba65281ba6732f2b2f61f73e95b6f48f7","src/vPtr.rs":"8b3e433d487180bb4304ff71245ecad90f0010f43e139a72027b672abe58facc","src/vSize.rs":"eda5aa020706cbf94d15bada41a0c2a35fc8f3f37cb7c2cd6f34d201399a495e","tests/endianness.rs":"5147f86d224c4c540b772033da2f994cad9bc9c035f38ec21e23bc4e55f8a759"},"package":null}
 \ No newline at end of file
 diff --git a/third_party/rust/packed_simd/.github/workflows/benchmarks.yml b/third_party/rust/packed_simd/.github/workflows/benchmarks.yml
 deleted file mode 100644
-index 2102661..0000000
 --- a/third_party/rust/packed_simd/.github/workflows/benchmarks.yml
 +++ /dev/null
 @@ -1,31 +0,0 @@
@@ -2881,7 +3824,6 @@ index 2102661..0000000
 -      # features: ispc
 diff --git a/third_party/rust/packed_simd/.github/workflows/ci.yml b/third_party/rust/packed_simd/.github/workflows/ci.yml
 deleted file mode 100644
-index 15f0963..0000000
 --- a/third_party/rust/packed_simd/.github/workflows/ci.yml
 +++ /dev/null
 @@ -1,218 +0,0 @@
@@ -3105,7 +4047,6 @@ index 15f0963..0000000
 -      rustflags: -Ctarget-feature=+neon
 diff --git a/third_party/rust/packed_simd/.github/workflows/docs.yml b/third_party/rust/packed_simd/.github/workflows/docs.yml
 deleted file mode 100644
-index 54bdc24..0000000
 --- a/third_party/rust/packed_simd/.github/workflows/docs.yml
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -3124,7 +4065,6 @@ index 54bdc24..0000000
 -      script: ci/dox.sh
 diff --git a/third_party/rust/packed_simd/.github/workflows/run-ci-script.yml b/third_party/rust/packed_simd/.github/workflows/run-ci-script.yml
 deleted file mode 100644
-index 733c539..0000000
 --- a/third_party/rust/packed_simd/.github/workflows/run-ci-script.yml
 +++ /dev/null
 @@ -1,86 +0,0 @@
@@ -3216,7 +4156,6 @@ index 733c539..0000000
 -          FEATURES: ${{ inputs.features }}
 diff --git a/third_party/rust/packed_simd/.travis.yml b/third_party/rust/packed_simd/.travis.yml
 deleted file mode 100644
-index 0ffc06a..0000000
 --- a/third_party/rust/packed_simd/.travis.yml
 +++ /dev/null
 @@ -1,212 +0,0 @@
@@ -3434,7 +4373,6 @@ index 0ffc06a..0000000
 -    on_success: never
 diff --git a/third_party/rust/packed_simd/Cargo.toml b/third_party/rust/packed_simd/Cargo.toml
 deleted file mode 100644
-index b73acdb..0000000
 --- a/third_party/rust/packed_simd/Cargo.toml
 +++ /dev/null
 @@ -1,80 +0,0 @@
@@ -3518,9 +4456,244 @@ index b73acdb..0000000
 -
 -[badges.maintenance]
 -status = "experimental"
+diff --git a/third_party/rust/packed_simd/LICENSE-APACHE b/third_party/rust/packed_simd/LICENSE-APACHE
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/LICENSE-APACHE
++++ /dev/null
+@@ -1,201 +0,0 @@
+-                              Apache License
+-                        Version 2.0, January 2004
+-                     http://www.apache.org/licenses/
+-
+-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+-
+-1. Definitions.
+-
+-   "License" shall mean the terms and conditions for use, reproduction,
+-   and distribution as defined by Sections 1 through 9 of this document.
+-
+-   "Licensor" shall mean the copyright owner or entity authorized by
+-   the copyright owner that is granting the License.
+-
+-   "Legal Entity" shall mean the union of the acting entity and all
+-   other entities that control, are controlled by, or are under common
+-   control with that entity. For the purposes of this definition,
+-   "control" means (i) the power, direct or indirect, to cause the
+-   direction or management of such entity, whether by contract or
+-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+-   outstanding shares, or (iii) beneficial ownership of such entity.
+-
+-   "You" (or "Your") shall mean an individual or Legal Entity
+-   exercising permissions granted by this License.
+-
+-   "Source" form shall mean the preferred form for making modifications,
+-   including but not limited to software source code, documentation
+-   source, and configuration files.
+-
+-   "Object" form shall mean any form resulting from mechanical
+-   transformation or translation of a Source form, including but
+-   not limited to compiled object code, generated documentation,
+-   and conversions to other media types.
+-
+-   "Work" shall mean the work of authorship, whether in Source or
+-   Object form, made available under the License, as indicated by a
+-   copyright notice that is included in or attached to the work
+-   (an example is provided in the Appendix below).
+-
+-   "Derivative Works" shall mean any work, whether in Source or Object
+-   form, that is based on (or derived from) the Work and for which the
+-   editorial revisions, annotations, elaborations, or other modifications
+-   represent, as a whole, an original work of authorship. For the purposes
+-   of this License, Derivative Works shall not include works that remain
+-   separable from, or merely link (or bind by name) to the interfaces of,
+-   the Work and Derivative Works thereof.
+-
+-   "Contribution" shall mean any work of authorship, including
+-   the original version of the Work and any modifications or additions
+-   to that Work or Derivative Works thereof, that is intentionally
+-   submitted to Licensor for inclusion in the Work by the copyright owner
+-   or by an individual or Legal Entity authorized to submit on behalf of
+-   the copyright owner. For the purposes of this definition, "submitted"
+-   means any form of electronic, verbal, or written communication sent
+-   to the Licensor or its representatives, including but not limited to
+-   communication on electronic mailing lists, source code control systems,
+-   and issue tracking systems that are managed by, or on behalf of, the
+-   Licensor for the purpose of discussing and improving the Work, but
+-   excluding communication that is conspicuously marked or otherwise
+-   designated in writing by the copyright owner as "Not a Contribution."
+-
+-   "Contributor" shall mean Licensor and any individual or Legal Entity
+-   on behalf of whom a Contribution has been received by Licensor and
+-   subsequently incorporated within the Work.
+-
+-2. Grant of Copyright License. Subject to the terms and conditions of
+-   this License, each Contributor hereby grants to You a perpetual,
+-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+-   copyright license to reproduce, prepare Derivative Works of,
+-   publicly display, publicly perform, sublicense, and distribute the
+-   Work and such Derivative Works in Source or Object form.
+-
+-3. Grant of Patent License. Subject to the terms and conditions of
+-   this License, each Contributor hereby grants to You a perpetual,
+-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+-   (except as stated in this section) patent license to make, have made,
+-   use, offer to sell, sell, import, and otherwise transfer the Work,
+-   where such license applies only to those patent claims licensable
+-   by such Contributor that are necessarily infringed by their
+-   Contribution(s) alone or by combination of their Contribution(s)
+-   with the Work to which such Contribution(s) was submitted. If You
+-   institute patent litigation against any entity (including a
+-   cross-claim or counterclaim in a lawsuit) alleging that the Work
+-   or a Contribution incorporated within the Work constitutes direct
+-   or contributory patent infringement, then any patent licenses
+-   granted to You under this License for that Work shall terminate
+-   as of the date such litigation is filed.
+-
+-4. Redistribution. You may reproduce and distribute copies of the
+-   Work or Derivative Works thereof in any medium, with or without
+-   modifications, and in Source or Object form, provided that You
+-   meet the following conditions:
+-
+-   (a) You must give any other recipients of the Work or
+-       Derivative Works a copy of this License; and
+-
+-   (b) You must cause any modified files to carry prominent notices
+-       stating that You changed the files; and
+-
+-   (c) You must retain, in the Source form of any Derivative Works
+-       that You distribute, all copyright, patent, trademark, and
+-       attribution notices from the Source form of the Work,
+-       excluding those notices that do not pertain to any part of
+-       the Derivative Works; and
+-
+-   (d) If the Work includes a "NOTICE" text file as part of its
+-       distribution, then any Derivative Works that You distribute must
+-       include a readable copy of the attribution notices contained
+-       within such NOTICE file, excluding those notices that do not
+-       pertain to any part of the Derivative Works, in at least one
+-       of the following places: within a NOTICE text file distributed
+-       as part of the Derivative Works; within the Source form or
+-       documentation, if provided along with the Derivative Works; or,
+-       within a display generated by the Derivative Works, if and
+-       wherever such third-party notices normally appear. The contents
+-       of the NOTICE file are for informational purposes only and
+-       do not modify the License. You may add Your own attribution
+-       notices within Derivative Works that You distribute, alongside
+-       or as an addendum to the NOTICE text from the Work, provided
+-       that such additional attribution notices cannot be construed
+-       as modifying the License.
+-
+-   You may add Your own copyright statement to Your modifications and
+-   may provide additional or different license terms and conditions
+-   for use, reproduction, or distribution of Your modifications, or
+-   for any such Derivative Works as a whole, provided Your use,
+-   reproduction, and distribution of the Work otherwise complies with
+-   the conditions stated in this License.
+-
+-5. Submission of Contributions. Unless You explicitly state otherwise,
+-   any Contribution intentionally submitted for inclusion in the Work
+-   by You to the Licensor shall be under the terms and conditions of
+-   this License, without any additional terms or conditions.
+-   Notwithstanding the above, nothing herein shall supersede or modify
+-   the terms of any separate license agreement you may have executed
+-   with Licensor regarding such Contributions.
+-
+-6. Trademarks. This License does not grant permission to use the trade
+-   names, trademarks, service marks, or product names of the Licensor,
+-   except as required for reasonable and customary use in describing the
+-   origin of the Work and reproducing the content of the NOTICE file.
+-
+-7. Disclaimer of Warranty. Unless required by applicable law or
+-   agreed to in writing, Licensor provides the Work (and each
+-   Contributor provides its Contributions) on an "AS IS" BASIS,
+-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+-   implied, including, without limitation, any warranties or conditions
+-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+-   PARTICULAR PURPOSE. You are solely responsible for determining the
+-   appropriateness of using or redistributing the Work and assume any
+-   risks associated with Your exercise of permissions under this License.
+-
+-8. Limitation of Liability. In no event and under no legal theory,
+-   whether in tort (including negligence), contract, or otherwise,
+-   unless required by applicable law (such as deliberate and grossly
+-   negligent acts) or agreed to in writing, shall any Contributor be
+-   liable to You for damages, including any direct, indirect, special,
+-   incidental, or consequential damages of any character arising as a
+-   result of this License or out of the use or inability to use the
+-   Work (including but not limited to damages for loss of goodwill,
+-   work stoppage, computer failure or malfunction, or any and all
+-   other commercial damages or losses), even if such Contributor
+-   has been advised of the possibility of such damages.
+-
+-9. Accepting Warranty or Additional Liability. While redistributing
+-   the Work or Derivative Works thereof, You may choose to offer,
+-   and charge a fee for, acceptance of support, warranty, indemnity,
+-   or other liability obligations and/or rights consistent with this
+-   License. However, in accepting such obligations, You may act only
+-   on Your own behalf and on Your sole responsibility, not on behalf
+-   of any other Contributor, and only if You agree to indemnify,
+-   defend, and hold each Contributor harmless for any liability
+-   incurred by, or claims asserted against, such Contributor by reason
+-   of your accepting any such warranty or additional liability.
+-
+-END OF TERMS AND CONDITIONS
+-
+-APPENDIX: How to apply the Apache License to your work.
+-
+-   To apply the Apache License to your work, attach the following
+-   boilerplate notice, with the fields enclosed by brackets "[]"
+-   replaced with your own identifying information. (Don't include
+-   the brackets!)  The text should be enclosed in the appropriate
+-   comment syntax for the file format. We also recommend that a
+-   file or class name and description of purpose be included on the
+-   same "printed page" as the copyright notice for easier
+-   identification within third-party archives.
+-
+-Copyright [yyyy] [name of copyright owner]
+-
+-Licensed under the Apache License, Version 2.0 (the "License");
+-you may not use this file except in compliance with the License.
+-You may obtain a copy of the License at
+-
+-	http://www.apache.org/licenses/LICENSE-2.0
+-
+-Unless required by applicable law or agreed to in writing, software
+-distributed under the License is distributed on an "AS IS" BASIS,
+-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-See the License for the specific language governing permissions and
+-limitations under the License.
+diff --git a/third_party/rust/packed_simd/LICENSE-MIT b/third_party/rust/packed_simd/LICENSE-MIT
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/LICENSE-MIT
++++ /dev/null
+@@ -1,25 +0,0 @@
+-Copyright (c) 2014 The Rust Project Developers
+-
+-Permission is hereby granted, free of charge, to any
+-person obtaining a copy of this software and associated
+-documentation files (the "Software"), to deal in the
+-Software without restriction, including without
+-limitation the rights to use, copy, modify, merge,
+-publish, distribute, sublicense, and/or sell copies of
+-the Software, and to permit persons to whom the Software
+-is furnished to do so, subject to the following
+-conditions:
+-
+-The above copyright notice and this permission notice
+-shall be included in all copies or substantial portions
+-of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+-DEALINGS IN THE SOFTWARE.
 diff --git a/third_party/rust/packed_simd/README.md b/third_party/rust/packed_simd/README.md
 deleted file mode 100644
-index 59db13f..0000000
 --- a/third_party/rust/packed_simd/README.md
 +++ /dev/null
 @@ -1,144 +0,0 @@
@@ -3670,7 +4843,6 @@ index 59db13f..0000000
 -[Code of Conduct]: https://www.rust-lang.org/en-US/conduct.html
 diff --git a/third_party/rust/packed_simd/bors.toml b/third_party/rust/packed_simd/bors.toml
 deleted file mode 100644
-index 6d302dc..0000000
 --- a/third_party/rust/packed_simd/bors.toml
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -3680,7 +4852,6 @@ index 6d302dc..0000000
 \ No newline at end of file
 diff --git a/third_party/rust/packed_simd/build.rs b/third_party/rust/packed_simd/build.rs
 deleted file mode 100644
-index e87298a..0000000
 --- a/third_party/rust/packed_simd/build.rs
 +++ /dev/null
 @@ -1,6 +0,0 @@
@@ -3692,7 +4863,6 @@ index e87298a..0000000
 -}
 diff --git a/third_party/rust/packed_simd/ci/all.sh b/third_party/rust/packed_simd/ci/all.sh
 deleted file mode 100644
-index 55a1fa2..0000000
 --- a/third_party/rust/packed_simd/ci/all.sh
 +++ /dev/null
 @@ -1,71 +0,0 @@
@@ -3769,7 +4939,6 @@ index 55a1fa2..0000000
 -)
 diff --git a/third_party/rust/packed_simd/ci/android-install-ndk.sh b/third_party/rust/packed_simd/ci/android-install-ndk.sh
 deleted file mode 100644
-index 5370853..0000000
 --- a/third_party/rust/packed_simd/ci/android-install-ndk.sh
 +++ /dev/null
 @@ -1,21 +0,0 @@
@@ -3796,7 +4965,6 @@ index 5370853..0000000
 -rm -rf android-ndk-*
 diff --git a/third_party/rust/packed_simd/ci/android-install-sdk.sh b/third_party/rust/packed_simd/ci/android-install-sdk.sh
 deleted file mode 100644
-index 6b5ac09..0000000
 --- a/third_party/rust/packed_simd/ci/android-install-sdk.sh
 +++ /dev/null
 @@ -1,60 +0,0 @@
@@ -3862,7 +5030,6 @@ index 6b5ac09..0000000
 -        --package "system-images;android-24;default;$abi"
 diff --git a/third_party/rust/packed_simd/ci/android-sysimage.sh b/third_party/rust/packed_simd/ci/android-sysimage.sh
 deleted file mode 100644
-index 9eabd7c..0000000
 --- a/third_party/rust/packed_simd/ci/android-sysimage.sh
 +++ /dev/null
 @@ -1,56 +0,0 @@
@@ -3924,7 +5091,6 @@ index 9eabd7c..0000000
 -main "${@}"
 diff --git a/third_party/rust/packed_simd/ci/benchmark.sh b/third_party/rust/packed_simd/ci/benchmark.sh
 deleted file mode 100644
-index 3635b9e..0000000
 --- a/third_party/rust/packed_simd/ci/benchmark.sh
 +++ /dev/null
 @@ -1,32 +0,0 @@
@@ -3962,7 +5128,6 @@ index 3635b9e..0000000
 -
 diff --git a/third_party/rust/packed_simd/ci/deploy_and_run_on_ios_simulator.rs b/third_party/rust/packed_simd/ci/deploy_and_run_on_ios_simulator.rs
 deleted file mode 100644
-index c0fe52c..0000000
 --- a/third_party/rust/packed_simd/ci/deploy_and_run_on_ios_simulator.rs
 +++ /dev/null
 @@ -1,176 +0,0 @@
@@ -4144,7 +5309,6 @@ index c0fe52c..0000000
 -}
 diff --git a/third_party/rust/packed_simd/ci/docker/aarch64-linux-android/Dockerfile b/third_party/rust/packed_simd/ci/docker/aarch64-linux-android/Dockerfile
 deleted file mode 100644
-index 27bde89..0000000
 --- a/third_party/rust/packed_simd/ci/docker/aarch64-linux-android/Dockerfile
 +++ /dev/null
 @@ -1,47 +0,0 @@
@@ -4197,7 +5361,6 @@ index 27bde89..0000000
 -]
 diff --git a/third_party/rust/packed_simd/ci/docker/aarch64-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index 41ff472..0000000
 --- a/third_party/rust/packed_simd/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,14 +0,0 @@
@@ -4217,7 +5380,6 @@ index 41ff472..0000000
 -    OBJDUMP=aarch64-linux-gnu-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/arm-unknown-linux-gnueabi/Dockerfile b/third_party/rust/packed_simd/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
 deleted file mode 100644
-index e1c591d..0000000
 --- a/third_party/rust/packed_simd/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
 +++ /dev/null
 @@ -1,15 +0,0 @@
@@ -4238,7 +5400,6 @@ index e1c591d..0000000
 -    OBJDUMP=arm-linux-gnueabi-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile b/third_party/rust/packed_simd/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
 deleted file mode 100644
-index 757b79e..0000000
 --- a/third_party/rust/packed_simd/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -4257,7 +5418,6 @@ index 757b79e..0000000
 -    OBJDUMP=arm-linux-gnueabihf-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/armv7-linux-androideabi/Dockerfile b/third_party/rust/packed_simd/ci/docker/armv7-linux-androideabi/Dockerfile
 deleted file mode 100644
-index 995a9e3..0000000
 --- a/third_party/rust/packed_simd/ci/docker/armv7-linux-androideabi/Dockerfile
 +++ /dev/null
 @@ -1,47 +0,0 @@
@@ -4310,7 +5470,6 @@ index 995a9e3..0000000
 -]
 diff --git a/third_party/rust/packed_simd/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile b/third_party/rust/packed_simd/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
 deleted file mode 100644
-index 2539062..0000000
 --- a/third_party/rust/packed_simd/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -4329,7 +5488,6 @@ index 2539062..0000000
 -    OBJDUMP=arm-linux-gnueabihf-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/i586-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/i586-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index 0109369..0000000
 --- a/third_party/rust/packed_simd/ci/docker/i586-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,7 +0,0 @@
@@ -4342,7 +5500,6 @@ index 0109369..0000000
 -  ca-certificates
 diff --git a/third_party/rust/packed_simd/ci/docker/i686-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/i686-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index 0109369..0000000
 --- a/third_party/rust/packed_simd/ci/docker/i686-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,7 +0,0 @@
@@ -4355,7 +5512,6 @@ index 0109369..0000000
 -  ca-certificates
 diff --git a/third_party/rust/packed_simd/ci/docker/mips-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/mips-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index 3bd471e..0000000
 --- a/third_party/rust/packed_simd/ci/docker/mips-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -4375,7 +5531,6 @@ index 3bd471e..0000000
 \ No newline at end of file
 diff --git a/third_party/rust/packed_simd/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile b/third_party/rust/packed_simd/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
 deleted file mode 100644
-index f26f1f3..0000000
 --- a/third_party/rust/packed_simd/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
 +++ /dev/null
 @@ -1,10 +0,0 @@
@@ -4392,7 +5547,6 @@ index f26f1f3..0000000
 \ No newline at end of file
 diff --git a/third_party/rust/packed_simd/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile b/third_party/rust/packed_simd/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
 deleted file mode 100644
-index 7d9f0bd..0000000
 --- a/third_party/rust/packed_simd/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
 +++ /dev/null
 @@ -1,10 +0,0 @@
@@ -4409,7 +5563,6 @@ index 7d9f0bd..0000000
 \ No newline at end of file
 diff --git a/third_party/rust/packed_simd/ci/docker/mipsel-unknown-linux-musl/Dockerfile b/third_party/rust/packed_simd/ci/docker/mipsel-unknown-linux-musl/Dockerfile
 deleted file mode 100644
-index 7488662..0000000
 --- a/third_party/rust/packed_simd/ci/docker/mipsel-unknown-linux-musl/Dockerfile
 +++ /dev/null
 @@ -1,25 +0,0 @@
@@ -4440,7 +5593,6 @@ index 7488662..0000000
 -    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mipsel -L /toolchain"
 diff --git a/third_party/rust/packed_simd/ci/docker/powerpc-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index 15ba58e..0000000
 --- a/third_party/rust/packed_simd/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -4459,7 +5611,6 @@ index 15ba58e..0000000
 -    OBJDUMP=powerpc-linux-gnu-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index 21c296d..0000000
 --- a/third_party/rust/packed_simd/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -4482,7 +5633,6 @@ index 21c296d..0000000
 -    OBJDUMP=powerpc64-linux-gnu-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index 8034145..0000000
 --- a/third_party/rust/packed_simd/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,11 +0,0 @@
@@ -4499,7 +5649,6 @@ index 8034145..0000000
 -    OBJDUMP=powerpc64le-linux-gnu-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/s390x-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/s390x-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index e785ca3..0000000
 --- a/third_party/rust/packed_simd/ci/docker/s390x-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,20 +0,0 @@
@@ -4525,7 +5674,6 @@ index e785ca3..0000000
 -    OBJDUMP=s390x-linux-gnu-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/sparc64-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
 deleted file mode 100644
-index c35f4d8..0000000
 --- a/third_party/rust/packed_simd/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -4549,7 +5697,6 @@ index c35f4d8..0000000
 -    PATH=$PATH:/rust/bin
 diff --git a/third_party/rust/packed_simd/ci/docker/thumbv7neon-linux-androideabi/Dockerfile b/third_party/rust/packed_simd/ci/docker/thumbv7neon-linux-androideabi/Dockerfile
 deleted file mode 100644
-index c1da771..0000000
 --- a/third_party/rust/packed_simd/ci/docker/thumbv7neon-linux-androideabi/Dockerfile
 +++ /dev/null
 @@ -1,47 +0,0 @@
@@ -4602,7 +5749,6 @@ index c1da771..0000000
 -]
 diff --git a/third_party/rust/packed_simd/ci/docker/thumbv7neon-unknown-linux-gnueabihf/Dockerfile b/third_party/rust/packed_simd/ci/docker/thumbv7neon-unknown-linux-gnueabihf/Dockerfile
 deleted file mode 100644
-index 588d23c..0000000
 --- a/third_party/rust/packed_simd/ci/docker/thumbv7neon-unknown-linux-gnueabihf/Dockerfile
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -4621,7 +5767,6 @@ index 588d23c..0000000
 -    OBJDUMP=arm-linux-gnueabihf-objdump
 diff --git a/third_party/rust/packed_simd/ci/docker/wasm32-unknown-unknown/Dockerfile b/third_party/rust/packed_simd/ci/docker/wasm32-unknown-unknown/Dockerfile
 deleted file mode 100644
-index 51ee13e..0000000
 --- a/third_party/rust/packed_simd/ci/docker/wasm32-unknown-unknown/Dockerfile
 +++ /dev/null
 @@ -1,39 +0,0 @@
@@ -4666,7 +5811,6 @@ index 51ee13e..0000000
 -ENTRYPOINT /rust/bin/rustc /lld-shim.rs -o /tmp/lld-shim && exec bash "$@"
 diff --git a/third_party/rust/packed_simd/ci/docker/x86_64-linux-android/Dockerfile b/third_party/rust/packed_simd/ci/docker/x86_64-linux-android/Dockerfile
 deleted file mode 100644
-index 785936d..0000000
 --- a/third_party/rust/packed_simd/ci/docker/x86_64-linux-android/Dockerfile
 +++ /dev/null
 @@ -1,31 +0,0 @@
@@ -4701,25 +5845,8 @@ index 785936d..0000000
 -    CXX_x86_64_linux_android=x86_64-linux-android21-clang++ \
 -    OBJDUMP=llvm-objdump \
 -    HOME=/tmp
-diff --git a/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
-deleted file mode 100644
-index ce5bb88..0000000
---- a/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
-+++ /dev/null
-@@ -1,10 +0,0 @@
--FROM ubuntu:18.04
--RUN apt-get update && apt-get install -y --no-install-recommends \
--  gcc \
--  libc6-dev \
--  file \
--  make \
--  ca-certificates \
--  cmake \
--  libclang-dev \
--  clang
 diff --git a/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile b/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
 deleted file mode 100644
-index a6bbe66..0000000
 --- a/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
 +++ /dev/null
 @@ -1,16 +0,0 @@
@@ -4739,9 +5866,23 @@ index a6bbe66..0000000
 -RUN wget https://github.com/gnzlbg/intel_sde/raw/master/sde-external-8.16.0-2018-01-30-lin.tar.bz2
 -RUN tar -xjf sde-external-8.16.0-2018-01-30-lin.tar.bz2
 -ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/sde-external-8.16.0-2018-01-30-lin/sde64 --"
+diff --git a/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu/Dockerfile b/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
++++ /dev/null
+@@ -1,10 +0,0 @@
+-FROM ubuntu:18.04
+-RUN apt-get update && apt-get install -y --no-install-recommends \
+-  gcc \
+-  libc6-dev \
+-  file \
+-  make \
+-  ca-certificates \
+-  cmake \
+-  libclang-dev \
+-  clang
 diff --git a/third_party/rust/packed_simd/ci/dox.sh b/third_party/rust/packed_simd/ci/dox.sh
 deleted file mode 100644
-index 560eaad..0000000
 --- a/third_party/rust/packed_simd/ci/dox.sh
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -4774,7 +5915,6 @@ index 560eaad..0000000
 -fi
 diff --git a/third_party/rust/packed_simd/ci/linux-s390x.sh b/third_party/rust/packed_simd/ci/linux-s390x.sh
 deleted file mode 100644
-index 972abee..0000000
 --- a/third_party/rust/packed_simd/ci/linux-s390x.sh
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -4798,7 +5938,6 @@ index 972abee..0000000
 -chmod a+w .
 diff --git a/third_party/rust/packed_simd/ci/linux-sparc64.sh b/third_party/rust/packed_simd/ci/linux-sparc64.sh
 deleted file mode 100644
-index 4452b12..0000000
 --- a/third_party/rust/packed_simd/ci/linux-sparc64.sh
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -4821,7 +5960,6 @@ index 4452b12..0000000
 -chmod a+w .
 diff --git a/third_party/rust/packed_simd/ci/lld-shim.rs b/third_party/rust/packed_simd/ci/lld-shim.rs
 deleted file mode 100644
-index 1026386..0000000
 --- a/third_party/rust/packed_simd/ci/lld-shim.rs
 +++ /dev/null
 @@ -1,11 +0,0 @@
@@ -4838,7 +5976,6 @@ index 1026386..0000000
 -}
 diff --git a/third_party/rust/packed_simd/ci/max_line_width.sh b/third_party/rust/packed_simd/ci/max_line_width.sh
 deleted file mode 100644
-index f70639b..0000000
 --- a/third_party/rust/packed_simd/ci/max_line_width.sh
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -4861,7 +5998,6 @@ index f70639b..0000000
 -
 diff --git a/third_party/rust/packed_simd/ci/run-docker.sh b/third_party/rust/packed_simd/ci/run-docker.sh
 deleted file mode 100644
-index abdd685..0000000
 --- a/third_party/rust/packed_simd/ci/run-docker.sh
 +++ /dev/null
 @@ -1,38 +0,0 @@
@@ -4905,7 +6041,6 @@ index abdd685..0000000
 -fi
 diff --git a/third_party/rust/packed_simd/ci/run.sh b/third_party/rust/packed_simd/ci/run.sh
 deleted file mode 100644
-index b1b22eb..0000000
 --- a/third_party/rust/packed_simd/ci/run.sh
 +++ /dev/null
 @@ -1,99 +0,0 @@
@@ -5010,7 +6145,6 @@ index b1b22eb..0000000
 -#. ci/run_examples.sh
 diff --git a/third_party/rust/packed_simd/ci/run_examples.sh b/third_party/rust/packed_simd/ci/run_examples.sh
 deleted file mode 100644
-index 5b26b18..0000000
 --- a/third_party/rust/packed_simd/ci/run_examples.sh
 +++ /dev/null
 @@ -1,51 +0,0 @@
@@ -5067,7 +6201,6 @@ index 5b26b18..0000000
 -cargo_test --manifest-path=target/triangle_xform/Cargo.toml --release
 diff --git a/third_party/rust/packed_simd/ci/runtest-android.rs b/third_party/rust/packed_simd/ci/runtest-android.rs
 deleted file mode 100644
-index ed1cd80..0000000
 --- a/third_party/rust/packed_simd/ci/runtest-android.rs
 +++ /dev/null
 @@ -1,45 +0,0 @@
@@ -5118,7 +6251,6 @@ index ed1cd80..0000000
 -}
 diff --git a/third_party/rust/packed_simd/ci/setup_benchmarks.sh b/third_party/rust/packed_simd/ci/setup_benchmarks.sh
 deleted file mode 100644
-index cd41a78..0000000
 --- a/third_party/rust/packed_simd/ci/setup_benchmarks.sh
 +++ /dev/null
 @@ -1,7 +0,0 @@
@@ -5131,7 +6263,6 @@ index cd41a78..0000000
 -cp ispc-binaries/ispc-${TARGET} ispc
 diff --git a/third_party/rust/packed_simd/ci/test-runner-linux b/third_party/rust/packed_simd/ci/test-runner-linux
 deleted file mode 100644
-index 0654f63..0000000
 --- a/third_party/rust/packed_simd/ci/test-runner-linux
 +++ /dev/null
 @@ -1,24 +0,0 @@
@@ -5161,7 +6292,6 @@ index 0654f63..0000000
 -! grep FAILED output > /dev/null
 diff --git a/third_party/rust/packed_simd/contributing.md b/third_party/rust/packed_simd/contributing.md
 deleted file mode 100644
-index 79af8c1..0000000
 --- a/third_party/rust/packed_simd/contributing.md
 +++ /dev/null
 @@ -1,67 +0,0 @@
@@ -5234,14 +6364,12 @@ index 79af8c1..0000000
 -[mdBook]: https://github.com/rust-lang-nursery/mdBook
 diff --git a/third_party/rust/packed_simd/perf-guide/.gitignore b/third_party/rust/packed_simd/perf-guide/.gitignore
 deleted file mode 100644
-index 5a0bf03..0000000
 --- a/third_party/rust/packed_simd/perf-guide/.gitignore
 +++ /dev/null
-@@ -1 +0,0 @@
+@@ -1,1 +0,0 @@
 -/book
 diff --git a/third_party/rust/packed_simd/perf-guide/book.toml b/third_party/rust/packed_simd/perf-guide/book.toml
 deleted file mode 100644
-index 69ba305..0000000
 --- a/third_party/rust/packed_simd/perf-guide/book.toml
 +++ /dev/null
 @@ -1,12 +0,0 @@
@@ -5259,7 +6387,6 @@ index 69ba305..0000000
 -additional-css = ["./src/ascii.css"]
 diff --git a/third_party/rust/packed_simd/perf-guide/src/SUMMARY.md b/third_party/rust/packed_simd/perf-guide/src/SUMMARY.md
 deleted file mode 100644
-index 1e76898..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/SUMMARY.md
 +++ /dev/null
 @@ -1,21 +0,0 @@
@@ -5286,7 +6413,6 @@ index 1e76898..0000000
 -  - [Using machine code analyzers](./prof/mca.md)
 diff --git a/third_party/rust/packed_simd/perf-guide/src/ascii.css b/third_party/rust/packed_simd/perf-guide/src/ascii.css
 deleted file mode 100644
-index 4c02651..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/ascii.css
 +++ /dev/null
 @@ -1,4 +0,0 @@
@@ -5296,7 +6422,6 @@ index 4c02651..0000000
 -}
 diff --git a/third_party/rust/packed_simd/perf-guide/src/bound_checks.md b/third_party/rust/packed_simd/perf-guide/src/bound_checks.md
 deleted file mode 100644
-index 2eeedb5..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/bound_checks.md
 +++ /dev/null
 @@ -1,22 +0,0 @@
@@ -5324,7 +6449,6 @@ index 2eeedb5..0000000
 -aware of them.
 diff --git a/third_party/rust/packed_simd/perf-guide/src/float-math/approx.md b/third_party/rust/packed_simd/perf-guide/src/float-math/approx.md
 deleted file mode 100644
-index 2237c67..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/float-math/approx.md
 +++ /dev/null
 @@ -1,8 +0,0 @@
@@ -5338,7 +6462,6 @@ index 2237c67..0000000
 --->
 diff --git a/third_party/rust/packed_simd/perf-guide/src/float-math/fma.md b/third_party/rust/packed_simd/perf-guide/src/float-math/fma.md
 deleted file mode 100644
-index 3577483..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/float-math/fma.md
 +++ /dev/null
 @@ -1,6 +0,0 @@
@@ -5350,7 +6473,6 @@ index 3577483..0000000
 --->
 diff --git a/third_party/rust/packed_simd/perf-guide/src/float-math/fp.md b/third_party/rust/packed_simd/perf-guide/src/float-math/fp.md
 deleted file mode 100644
-index 711fcc4..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/float-math/fp.md
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -5359,7 +6481,6 @@ index 711fcc4..0000000
 -This chapter contains information pertaining to working with floating-point numbers.
 diff --git a/third_party/rust/packed_simd/perf-guide/src/float-math/svml.md b/third_party/rust/packed_simd/perf-guide/src/float-math/svml.md
 deleted file mode 100644
-index 266c253..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/float-math/svml.md
 +++ /dev/null
 @@ -1,7 +0,0 @@
@@ -5372,7 +6493,6 @@ index 266c253..0000000
 --->
 diff --git a/third_party/rust/packed_simd/perf-guide/src/introduction.md b/third_party/rust/packed_simd/perf-guide/src/introduction.md
 deleted file mode 100644
-index 7243e19..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/introduction.md
 +++ /dev/null
 @@ -1,26 +0,0 @@
@@ -5404,7 +6524,6 @@ index 7243e19..0000000
 -on how to apply the tips to _your_ code.
 diff --git a/third_party/rust/packed_simd/perf-guide/src/prof/linux.md b/third_party/rust/packed_simd/perf-guide/src/prof/linux.md
 deleted file mode 100644
-index 96c7d67..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/prof/linux.md
 +++ /dev/null
 @@ -1,107 +0,0 @@
@@ -5517,7 +6636,6 @@ index 96c7d67..0000000
 --->
 diff --git a/third_party/rust/packed_simd/perf-guide/src/prof/mca.md b/third_party/rust/packed_simd/perf-guide/src/prof/mca.md
 deleted file mode 100644
-index 65ddf1a..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/prof/mca.md
 +++ /dev/null
 @@ -1,100 +0,0 @@
@@ -5623,7 +6741,6 @@ index 65ddf1a..0000000
 --->
 diff --git a/third_party/rust/packed_simd/perf-guide/src/prof/profiling.md b/third_party/rust/packed_simd/perf-guide/src/prof/profiling.md
 deleted file mode 100644
-index 02ba78d..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/prof/profiling.md
 +++ /dev/null
 @@ -1,14 +0,0 @@
@@ -5643,7 +6760,6 @@ index 02ba78d..0000000
 -[cargo-ref]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections
 diff --git a/third_party/rust/packed_simd/perf-guide/src/target-feature/attribute.md b/third_party/rust/packed_simd/perf-guide/src/target-feature/attribute.md
 deleted file mode 100644
-index ee670fe..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/target-feature/attribute.md
 +++ /dev/null
 @@ -1,5 +0,0 @@
@@ -5654,7 +6770,6 @@ index ee670fe..0000000
 --->
 diff --git a/third_party/rust/packed_simd/perf-guide/src/target-feature/features.md b/third_party/rust/packed_simd/perf-guide/src/target-feature/features.md
 deleted file mode 100644
-index b93030c..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/target-feature/features.md
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -5673,7 +6788,6 @@ index b93030c..0000000
 -[targets]: https://github.com/rust-lang/rust/tree/master/src/librustc_target/spec
 diff --git a/third_party/rust/packed_simd/perf-guide/src/target-feature/inlining.md b/third_party/rust/packed_simd/perf-guide/src/target-feature/inlining.md
 deleted file mode 100644
-index 8670510..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/target-feature/inlining.md
 +++ /dev/null
 @@ -1,5 +0,0 @@
@@ -5684,7 +6798,6 @@ index 8670510..0000000
 --->
 diff --git a/third_party/rust/packed_simd/perf-guide/src/target-feature/practice.md b/third_party/rust/packed_simd/perf-guide/src/target-feature/practice.md
 deleted file mode 100644
-index 5b55c61..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/target-feature/practice.md
 +++ /dev/null
 @@ -1,31 +0,0 @@
@@ -5721,7 +6834,6 @@ index 5b55c61..0000000
 -[VEX]: https://en.wikipedia.org/wiki/VEX_prefix
 diff --git a/third_party/rust/packed_simd/perf-guide/src/target-feature/runtime.md b/third_party/rust/packed_simd/perf-guide/src/target-feature/runtime.md
 deleted file mode 100644
-index 47ddcc8..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/target-feature/runtime.md
 +++ /dev/null
 @@ -1,5 +0,0 @@
@@ -5732,7 +6844,6 @@ index 47ddcc8..0000000
 --->
 diff --git a/third_party/rust/packed_simd/perf-guide/src/target-feature/rustflags.md b/third_party/rust/packed_simd/perf-guide/src/target-feature/rustflags.md
 deleted file mode 100644
-index f4c1d13..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/target-feature/rustflags.md
 +++ /dev/null
 @@ -1,77 +0,0 @@
@@ -5815,7 +6926,6 @@ index f4c1d13..0000000
 -  or cross-compiling.
 diff --git a/third_party/rust/packed_simd/perf-guide/src/vert-hor-ops.md b/third_party/rust/packed_simd/perf-guide/src/vert-hor-ops.md
 deleted file mode 100644
-index d0dd1be..0000000
 --- a/third_party/rust/packed_simd/perf-guide/src/vert-hor-ops.md
 +++ /dev/null
 @@ -1,76 +0,0 @@
@@ -5897,7 +7007,6 @@ index d0dd1be..0000000
 -addition is 2.7x slower than the one using vertical vector operations!
 diff --git a/third_party/rust/packed_simd/rustfmt.toml b/third_party/rust/packed_simd/rustfmt.toml
 deleted file mode 100644
-index 7316518..0000000
 --- a/third_party/rust/packed_simd/rustfmt.toml
 +++ /dev/null
 @@ -1,5 +0,0 @@
@@ -5907,9 +7016,321 @@ index 7316518..0000000
 -edition = "2018"
 -error_on_line_overflow = true
 \ No newline at end of file
+diff --git a/third_party/rust/packed_simd/src/api.rs b/third_party/rust/packed_simd/src/api.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/api.rs
++++ /dev/null
+@@ -1,308 +0,0 @@
+-//! Implements the Simd<[T; N]> APIs
+-
+-#[macro_use]
+-mod bitmask;
+-pub(crate) mod cast;
+-#[macro_use]
+-mod cmp;
+-#[macro_use]
+-mod default;
+-#[macro_use]
+-mod fmt;
+-#[macro_use]
+-mod from;
+-#[macro_use]
+-mod hash;
+-#[macro_use]
+-mod math;
+-#[macro_use]
+-mod minimal;
+-#[macro_use]
+-mod ops;
+-#[macro_use]
+-mod ptr;
+-#[macro_use]
+-mod reductions;
+-#[macro_use]
+-mod select;
+-#[macro_use]
+-mod shuffle;
+-#[macro_use]
+-mod shuffle1_dyn;
+-#[macro_use]
+-mod slice;
+-#[macro_use]
+-mod swap_bytes;
+-#[macro_use]
+-mod bit_manip;
+-
+-#[cfg(feature = "into_bits")]
+-pub(crate) mod into_bits;
+-
+-macro_rules! impl_i {
+-    ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident
+-     | $ielem_ty:ident, $ibitmask_ty:ident | $test_tt:tt | $($elem_ids:ident),*
+-     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
+-        impl_minimal_iuf!([$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-                          | $($elem_ids),* | $(#[$doc])*);
+-        impl_ops_vector_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_scalar_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_bitwise!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (!(0 as $elem_ty), 0)
+-        );
+-        impl_ops_scalar_bitwise!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (!(0 as $elem_ty), 0)
+-        );
+-        impl_ops_vector_shifts!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_scalar_shifts!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_rotates!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_neg!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_int_min_max!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt
+-        );
+-        impl_reduction_integer_arithmetic!(
+-            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-        );
+-        impl_reduction_min_max!(
+-            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-        );
+-        impl_reduction_bitwise!(
+-            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-            | (|x|{ x as $elem_ty }) | (!(0 as $elem_ty), 0)
+-        );
+-        impl_fmt_debug!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_lower_hex!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_upper_hex!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_octal!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_binary!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_from_array!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (1, 1));
+-        impl_from_vectors!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*
+-        );
+-        impl_default!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_hash!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_swap_bytes!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_bit_manip!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_partial_eq!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1)
+-        );
+-        impl_cmp_eq!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
+-        impl_cmp_vertical!(
+-            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, false, (1, 0) | $test_tt
+-        );
+-        impl_cmp_partial_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
+-        impl_bitmask!($tuple_id | $ibitmask_ty | (-1, 0) | $test_tt);
+-
+-        test_select!($elem_ty, $mask_ty, $tuple_id, (1, 2) | $test_tt);
+-        test_cmp_partial_ord_int!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-    }
+-}
+-
+-macro_rules! impl_u {
+-    ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident
+-     | $ielem_ty:ident, $ibitmask_ty:ident | $test_tt:tt | $($elem_ids:ident),*
+-     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
+-        impl_minimal_iuf!([$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-                          | $($elem_ids),* | $(#[$doc])*);
+-        impl_ops_vector_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_scalar_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_bitwise!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (!(0 as $elem_ty), 0)
+-        );
+-        impl_ops_scalar_bitwise!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (!(0 as $elem_ty), 0)
+-        );
+-        impl_ops_vector_shifts!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_scalar_shifts!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_rotates!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_int_min_max!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt
+-        );
+-        impl_reduction_integer_arithmetic!(
+-            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-        );
+-        impl_reduction_min_max!(
+-            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-        );
+-        impl_reduction_bitwise!(
+-            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-            | (|x|{ x as $elem_ty }) | (!(0 as $elem_ty), 0)
+-        );
+-        impl_fmt_debug!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_lower_hex!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_upper_hex!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_octal!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_binary!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_from_array!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (1, 1));
+-        impl_from_vectors!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*
+-        );
+-        impl_default!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_hash!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_swap_bytes!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_bit_manip!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_partial_eq!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (1, 0)
+-        );
+-        impl_cmp_eq!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
+-        impl_cmp_vertical!(
+-            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, false, (1, 0) | $test_tt
+-        );
+-        impl_cmp_partial_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
+-        impl_bitmask!($tuple_id | $ibitmask_ty | ($ielem_ty::max_value(), 0) |
+-                      $test_tt);
+-
+-        test_select!($elem_ty, $mask_ty, $tuple_id, (1, 2) | $test_tt);
+-        test_cmp_partial_ord_int!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-    }
+-}
+-
+-macro_rules! impl_f {
+-    ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident
+-     | $ielem_ty:ident | $test_tt:tt | $($elem_ids:ident),*
+-     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
+-        impl_minimal_iuf!([$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-                          | $($elem_ids),* | $(#[$doc])*);
+-        impl_ops_vector_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_scalar_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_neg!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_ops_vector_float_min_max!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt
+-        );
+-        impl_reduction_float_arithmetic!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_reduction_min_max!(
+-            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-        );
+-        impl_fmt_debug!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_from_array!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (1., 1.));
+-        impl_from_vectors!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*
+-        );
+-        impl_default!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_partial_eq!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (1., 0.)
+-        );
+-        impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-
+-        impl_float_consts!([$elem_ty; $elem_n]: $tuple_id);
+-        impl_float_category!([$elem_ty; $elem_n]: $tuple_id, $mask_ty);
+-
+-        // floating-point math
+-        impl_math_float_abs!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_cos!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_exp!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_ln!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_mul_add!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_mul_adde!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_powf!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_recpre!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_rsqrte!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_sin!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_sqrt!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_math_float_sqrte!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_vertical!(
+-            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, false, (1., 0.)
+-                | $test_tt
+-        );
+-
+-        test_select!($elem_ty, $mask_ty, $tuple_id, (1., 2.) | $test_tt);
+-        test_reduction_float_min_max!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt
+-        );
+-        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-    }
+-}
+-
+-macro_rules! impl_m {
+-    ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident
+-     | $ielem_ty:ident, $ibitmask_ty:ident
+-     | $test_tt:tt | $($elem_ids:ident),* | From: $($from_vec_ty:ident),*
+-     | $(#[$doc:meta])*) => {
+-        impl_minimal_mask!(
+-            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-            | $($elem_ids),* | $(#[$doc])*
+-        );
+-        impl_ops_vector_mask_bitwise!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (true, false)
+-        );
+-        impl_ops_scalar_mask_bitwise!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (true, false)
+-        );
+-        impl_reduction_bitwise!(
+-            [bool; $elem_n]: $tuple_id | $ielem_ty | $test_tt
+-                | (|x|{ x != 0 }) | (true, false)
+-        );
+-        impl_reduction_mask!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_fmt_debug!([bool; $elem_n]: $tuple_id | $test_tt);
+-        impl_from_array!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt
+-            | (crate::$elem_ty::new(true), true)
+-        );
+-        impl_from_vectors!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*
+-        );
+-        impl_default!([bool; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_partial_eq!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (true, false)
+-        );
+-        impl_cmp_eq!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (true, false)
+-        );
+-        impl_cmp_vertical!(
+-            [$elem_ty; $elem_n]: $tuple_id, $tuple_id, true, (true, false)
+-            | $test_tt
+-        );
+-        impl_select!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_partial_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_cmp_ord!(
+-            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (false, true)
+-        );
+-        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl_bitmask!($tuple_id | $ibitmask_ty | (true, false) | $test_tt);
+-
+-        test_cmp_partial_ord_mask!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        test_shuffle1_dyn_mask!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-    }
+-}
+-
+-macro_rules! impl_const_p {
+-    ([$elem_ty:ty; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident,
+-     $usize_ty:ident, $isize_ty:ident
+-     | $test_tt:tt | $($elem_ids:ident),*
+-     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
+-        impl_minimal_p!(
+-            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, $usize_ty, $isize_ty
+-                | ref_ | $test_tt | $($elem_ids),*
+-                | (1 as $elem_ty, 0 as $elem_ty) | $(#[$doc])*
+-        );
+-        impl_ptr_read!([$elem_ty; $elem_n]: $tuple_id, $mask_ty | $test_tt);
+-    }
+-}
+-
+-macro_rules! impl_mut_p {
+-    ([$elem_ty:ty; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident,
+-     $usize_ty:ident, $isize_ty:ident
+-     | $test_tt:tt | $($elem_ids:ident),*
+-     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
+-        impl_minimal_p!(
+-            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, $usize_ty, $isize_ty
+-                | ref_mut_ | $test_tt | $($elem_ids),*
+-                | (1 as $elem_ty, 0 as $elem_ty) | $(#[$doc])*
+-        );
+-        impl_ptr_read!([$elem_ty; $elem_n]: $tuple_id, $mask_ty | $test_tt);
+-        impl_ptr_write!([$elem_ty; $elem_n]: $tuple_id, $mask_ty | $test_tt);
+-    }
+-}
 diff --git a/third_party/rust/packed_simd/src/api/bit_manip.rs b/third_party/rust/packed_simd/src/api/bit_manip.rs
 deleted file mode 100644
-index c1e90bb..0000000
 --- a/third_party/rust/packed_simd/src/api/bit_manip.rs
 +++ /dev/null
 @@ -1,129 +0,0 @@
@@ -6044,7 +7465,6 @@ index c1e90bb..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/bitmask.rs b/third_party/rust/packed_simd/src/api/bitmask.rs
 deleted file mode 100644
-index 8f4868f..0000000
 --- a/third_party/rust/packed_simd/src/api/bitmask.rs
 +++ /dev/null
 @@ -1,79 +0,0 @@
@@ -6127,9 +7547,121 @@ index 8f4868f..0000000
 -        }
 -    };
 -}
+diff --git a/third_party/rust/packed_simd/src/api/cast.rs b/third_party/rust/packed_simd/src/api/cast.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/api/cast.rs
++++ /dev/null
+@@ -1,108 +0,0 @@
+-//! Implementation of `FromCast` and `IntoCast`.
+-#![allow(clippy::module_name_repetitions)]
+-
+-/// Numeric cast from `T` to `Self`.
+-///
+-/// > Note: This is a temporary workaround until the conversion traits
+-/// specified > in [RFC2484] are implemented.
+-///
+-/// Numeric cast between vectors with the same number of lanes, such that:
+-///
+-/// * casting integer vectors whose lane types have the same size (e.g. `i32xN`
+-/// -> `u32xN`) is a **no-op**,
+-///
+-/// * casting from a larger integer to a smaller integer (e.g. `u32xN` ->
+-/// `u8xN`) will **truncate**,
+-///
+-/// * casting from a smaller integer to a larger integer   (e.g. `u8xN` ->
+-///   `u32xN`) will:
+-///    * **zero-extend** if the source is unsigned, or
+-///    * **sign-extend** if the source is signed,
+-///
+-/// * casting from a float to an integer will **round the float towards zero**,
+-///
+-/// * casting from an integer to float will produce the floating point
+-/// representation of the integer, **rounding to nearest, ties to even**,
+-///
+-/// * casting from an `f32` to an `f64` is perfect and lossless,
+-///
+-/// * casting from an `f64` to an `f32` **rounds to nearest, ties to even**.
+-///
+-/// [RFC2484]: https://github.com/rust-lang/rfcs/pull/2484
+-pub trait FromCast<T>: crate::marker::Sized {
+-    /// Numeric cast from `T` to `Self`.
+-    fn from_cast(_: T) -> Self;
+-}
+-
+-/// Numeric cast from `Self` to `T`.
+-///
+-/// > Note: This is a temporary workaround until the conversion traits
+-/// specified > in [RFC2484] are implemented.
+-///
+-/// Numeric cast between vectors with the same number of lanes, such that:
+-///
+-/// * casting integer vectors whose lane types have the same size (e.g. `i32xN`
+-/// -> `u32xN`) is a **no-op**,
+-///
+-/// * casting from a larger integer to a smaller integer (e.g. `u32xN` ->
+-/// `u8xN`) will **truncate**,
+-///
+-/// * casting from a smaller integer to a larger integer   (e.g. `u8xN` ->
+-///   `u32xN`) will:
+-///    * **zero-extend** if the source is unsigned, or
+-///    * **sign-extend** if the source is signed,
+-///
+-/// * casting from a float to an integer will **round the float towards zero**,
+-///
+-/// * casting from an integer to float will produce the floating point
+-/// representation of the integer, **rounding to nearest, ties to even**,
+-///
+-/// * casting from an `f32` to an `f64` is perfect and lossless,
+-///
+-/// * casting from an `f64` to an `f32` **rounds to nearest, ties to even**.
+-///
+-/// [RFC2484]: https://github.com/rust-lang/rfcs/pull/2484
+-pub trait Cast<T>: crate::marker::Sized {
+-    /// Numeric cast from `self` to `T`.
+-    fn cast(self) -> T;
+-}
+-
+-/// `FromCast` implies `Cast`.
+-impl<T, U> Cast<U> for T
+-where
+-    U: FromCast<T>,
+-{
+-    #[inline]
+-    fn cast(self) -> U {
+-        U::from_cast(self)
+-    }
+-}
+-
+-/// `FromCast` and `Cast` are reflexive
+-impl<T> FromCast<T> for T {
+-    #[inline]
+-    fn from_cast(t: Self) -> Self {
+-        t
+-    }
+-}
+-
+-#[macro_use]
+-mod macros;
+-
+-mod v16;
+-pub use self::v16::*;
+-
+-mod v32;
+-pub use self::v32::*;
+-
+-mod v64;
+-pub use self::v64::*;
+-
+-mod v128;
+-pub use self::v128::*;
+-
+-mod v256;
+-pub use self::v256::*;
+-
+-mod v512;
+-pub use self::v512::*;
 diff --git a/third_party/rust/packed_simd/src/api/cast/macros.rs b/third_party/rust/packed_simd/src/api/cast/macros.rs
 deleted file mode 100644
-index 3bb29f0..0000000
 --- a/third_party/rust/packed_simd/src/api/cast/macros.rs
 +++ /dev/null
 @@ -1,82 +0,0 @@
@@ -6217,7 +7749,6 @@ index 3bb29f0..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/cast/v128.rs b/third_party/rust/packed_simd/src/api/cast/v128.rs
 deleted file mode 100644
-index 2e10b97..0000000
 --- a/third_party/rust/packed_simd/src/api/cast/v128.rs
 +++ /dev/null
 @@ -1,302 +0,0 @@
@@ -6525,7 +8056,6 @@ index 2e10b97..0000000
 -impl_from_cast!(m128x1[test_v128]: i128x1, u128x1);
 diff --git a/third_party/rust/packed_simd/src/api/cast/v16.rs b/third_party/rust/packed_simd/src/api/cast/v16.rs
 deleted file mode 100644
-index 896feba..0000000
 --- a/third_party/rust/packed_simd/src/api/cast/v16.rs
 +++ /dev/null
 @@ -1,68 +0,0 @@
@@ -6599,7 +8129,6 @@ index 896feba..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/api/cast/v256.rs b/third_party/rust/packed_simd/src/api/cast/v256.rs
 deleted file mode 100644
-index fe0c835..0000000
 --- a/third_party/rust/packed_simd/src/api/cast/v256.rs
 +++ /dev/null
 @@ -1,298 +0,0 @@
@@ -6903,7 +8432,6 @@ index fe0c835..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/api/cast/v32.rs b/third_party/rust/packed_simd/src/api/cast/v32.rs
 deleted file mode 100644
-index 4ad1cbf..0000000
 --- a/third_party/rust/packed_simd/src/api/cast/v32.rs
 +++ /dev/null
 @@ -1,132 +0,0 @@
@@ -7041,7 +8569,6 @@ index 4ad1cbf..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/api/cast/v512.rs b/third_party/rust/packed_simd/src/api/cast/v512.rs
 deleted file mode 100644
-index b646050..0000000
 --- a/third_party/rust/packed_simd/src/api/cast/v512.rs
 +++ /dev/null
 @@ -1,209 +0,0 @@
@@ -7256,7 +8783,6 @@ index b646050..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/api/cast/v64.rs b/third_party/rust/packed_simd/src/api/cast/v64.rs
 deleted file mode 100644
-index b23d1a4..0000000
 --- a/third_party/rust/packed_simd/src/api/cast/v64.rs
 +++ /dev/null
 @@ -1,208 +0,0 @@
@@ -7468,123 +8994,29 @@ index b23d1a4..0000000
 -    usizex2,
 -    msizex2
 -);
-diff --git a/third_party/rust/packed_simd/src/api/cast.rs b/third_party/rust/packed_simd/src/api/cast.rs
+diff --git a/third_party/rust/packed_simd/src/api/cmp.rs b/third_party/rust/packed_simd/src/api/cmp.rs
 deleted file mode 100644
-index f1c32ca..0000000
---- a/third_party/rust/packed_simd/src/api/cast.rs
+--- a/third_party/rust/packed_simd/src/api/cmp.rs
 +++ /dev/null
-@@ -1,108 +0,0 @@
--//! Implementation of `FromCast` and `IntoCast`.
--#![allow(clippy::module_name_repetitions)]
--
--/// Numeric cast from `T` to `Self`.
--///
--/// > Note: This is a temporary workaround until the conversion traits
--/// specified > in [RFC2484] are implemented.
--///
--/// Numeric cast between vectors with the same number of lanes, such that:
--///
--/// * casting integer vectors whose lane types have the same size (e.g. `i32xN`
--/// -> `u32xN`) is a **no-op**,
--///
--/// * casting from a larger integer to a smaller integer (e.g. `u32xN` ->
--/// `u8xN`) will **truncate**,
--///
--/// * casting from a smaller integer to a larger integer   (e.g. `u8xN` ->
--///   `u32xN`) will:
--///    * **zero-extend** if the source is unsigned, or
--///    * **sign-extend** if the source is signed,
--///
--/// * casting from a float to an integer will **round the float towards zero**,
--///
--/// * casting from an integer to float will produce the floating point
--/// representation of the integer, **rounding to nearest, ties to even**,
--///
--/// * casting from an `f32` to an `f64` is perfect and lossless,
--///
--/// * casting from an `f64` to an `f32` **rounds to nearest, ties to even**.
--///
--/// [RFC2484]: https://github.com/rust-lang/rfcs/pull/2484
--pub trait FromCast<T>: crate::marker::Sized {
--    /// Numeric cast from `T` to `Self`.
--    fn from_cast(_: T) -> Self;
--}
--
--/// Numeric cast from `Self` to `T`.
--///
--/// > Note: This is a temporary workaround until the conversion traits
--/// specified > in [RFC2484] are implemented.
--///
--/// Numeric cast between vectors with the same number of lanes, such that:
--///
--/// * casting integer vectors whose lane types have the same size (e.g. `i32xN`
--/// -> `u32xN`) is a **no-op**,
--///
--/// * casting from a larger integer to a smaller integer (e.g. `u32xN` ->
--/// `u8xN`) will **truncate**,
--///
--/// * casting from a smaller integer to a larger integer   (e.g. `u8xN` ->
--///   `u32xN`) will:
--///    * **zero-extend** if the source is unsigned, or
--///    * **sign-extend** if the source is signed,
--///
--/// * casting from a float to an integer will **round the float towards zero**,
--///
--/// * casting from an integer to float will produce the floating point
--/// representation of the integer, **rounding to nearest, ties to even**,
--///
--/// * casting from an `f32` to an `f64` is perfect and lossless,
--///
--/// * casting from an `f64` to an `f32` **rounds to nearest, ties to even**.
--///
--/// [RFC2484]: https://github.com/rust-lang/rfcs/pull/2484
--pub trait Cast<T>: crate::marker::Sized {
--    /// Numeric cast from `self` to `T`.
--    fn cast(self) -> T;
--}
--
--/// `FromCast` implies `Cast`.
--impl<T, U> Cast<U> for T
--where
--    U: FromCast<T>,
--{
--    #[inline]
--    fn cast(self) -> U {
--        U::from_cast(self)
--    }
--}
--
--/// `FromCast` and `Cast` are reflexive
--impl<T> FromCast<T> for T {
--    #[inline]
--    fn from_cast(t: Self) -> Self {
--        t
--    }
--}
+@@ -1,16 +0,0 @@
+-//! Implement cmp traits for vector types
 -
 -#[macro_use]
--mod macros;
+-mod partial_eq;
 -
--mod v16;
--pub use self::v16::*;
+-#[macro_use]
+-mod eq;
 -
--mod v32;
--pub use self::v32::*;
+-#[macro_use]
+-mod partial_ord;
 -
--mod v64;
--pub use self::v64::*;
+-#[macro_use]
+-mod ord;
 -
--mod v128;
--pub use self::v128::*;
--
--mod v256;
--pub use self::v256::*;
--
--mod v512;
--pub use self::v512::*;
+-#[macro_use]
+-mod vertical;
 diff --git a/third_party/rust/packed_simd/src/api/cmp/eq.rs b/third_party/rust/packed_simd/src/api/cmp/eq.rs
 deleted file mode 100644
-index 3c55d0d..0000000
 --- a/third_party/rust/packed_simd/src/api/cmp/eq.rs
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -7617,7 +9049,6 @@ index 3c55d0d..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/cmp/ord.rs b/third_party/rust/packed_simd/src/api/cmp/ord.rs
 deleted file mode 100644
-index e54ba3b..0000000
 --- a/third_party/rust/packed_simd/src/api/cmp/ord.rs
 +++ /dev/null
 @@ -1,43 +0,0 @@
@@ -7666,7 +9097,6 @@ index e54ba3b..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/cmp/partial_eq.rs b/third_party/rust/packed_simd/src/api/cmp/partial_eq.rs
 deleted file mode 100644
-index d69dd47..0000000
 --- a/third_party/rust/packed_simd/src/api/cmp/partial_eq.rs
 +++ /dev/null
 @@ -1,65 +0,0 @@
@@ -7737,7 +9167,6 @@ index d69dd47..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/cmp/partial_ord.rs b/third_party/rust/packed_simd/src/api/cmp/partial_ord.rs
 deleted file mode 100644
-index 76ed9eb..0000000
 --- a/third_party/rust/packed_simd/src/api/cmp/partial_ord.rs
 +++ /dev/null
 @@ -1,230 +0,0 @@
@@ -7973,7 +9402,6 @@ index 76ed9eb..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/cmp/vertical.rs b/third_party/rust/packed_simd/src/api/cmp/vertical.rs
 deleted file mode 100644
-index ea4a0d1..0000000
 --- a/third_party/rust/packed_simd/src/api/cmp/vertical.rs
 +++ /dev/null
 @@ -1,114 +0,0 @@
@@ -8091,31 +9519,8 @@ index ea4a0d1..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api/cmp.rs b/third_party/rust/packed_simd/src/api/cmp.rs
-deleted file mode 100644
-index 6d5301d..0000000
---- a/third_party/rust/packed_simd/src/api/cmp.rs
-+++ /dev/null
-@@ -1,16 +0,0 @@
--//! Implement cmp traits for vector types
--
--#[macro_use]
--mod partial_eq;
--
--#[macro_use]
--mod eq;
--
--#[macro_use]
--mod partial_ord;
--
--#[macro_use]
--mod ord;
--
--#[macro_use]
--mod vertical;
 diff --git a/third_party/rust/packed_simd/src/api/default.rs b/third_party/rust/packed_simd/src/api/default.rs
 deleted file mode 100644
-index 7af55ea..0000000
 --- a/third_party/rust/packed_simd/src/api/default.rs
 +++ /dev/null
 @@ -1,30 +0,0 @@
@@ -8149,9 +9554,25 @@ index 7af55ea..0000000
 -        }
 -    };
 -}
+diff --git a/third_party/rust/packed_simd/src/api/fmt.rs b/third_party/rust/packed_simd/src/api/fmt.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/api/fmt.rs
++++ /dev/null
+@@ -1,12 +0,0 @@
+-//! Implements formatting APIs
+-
+-#[macro_use]
+-mod debug;
+-#[macro_use]
+-mod lower_hex;
+-#[macro_use]
+-mod upper_hex;
+-#[macro_use]
+-mod octal;
+-#[macro_use]
+-mod binary;
 diff --git a/third_party/rust/packed_simd/src/api/fmt/binary.rs b/third_party/rust/packed_simd/src/api/fmt/binary.rs
 deleted file mode 100644
-index 91c0825..0000000
 --- a/third_party/rust/packed_simd/src/api/fmt/binary.rs
 +++ /dev/null
 @@ -1,54 +0,0 @@
@@ -8211,7 +9632,6 @@ index 91c0825..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/fmt/debug.rs b/third_party/rust/packed_simd/src/api/fmt/debug.rs
 deleted file mode 100644
-index 1e209b3..0000000
 --- a/third_party/rust/packed_simd/src/api/fmt/debug.rs
 +++ /dev/null
 @@ -1,60 +0,0 @@
@@ -8277,7 +9697,6 @@ index 1e209b3..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/fmt/lower_hex.rs b/third_party/rust/packed_simd/src/api/fmt/lower_hex.rs
 deleted file mode 100644
-index 8f11d31..0000000
 --- a/third_party/rust/packed_simd/src/api/fmt/lower_hex.rs
 +++ /dev/null
 @@ -1,54 +0,0 @@
@@ -8337,7 +9756,6 @@ index 8f11d31..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/fmt/octal.rs b/third_party/rust/packed_simd/src/api/fmt/octal.rs
 deleted file mode 100644
-index e708e09..0000000
 --- a/third_party/rust/packed_simd/src/api/fmt/octal.rs
 +++ /dev/null
 @@ -1,54 +0,0 @@
@@ -8397,7 +9815,6 @@ index e708e09..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/fmt/upper_hex.rs b/third_party/rust/packed_simd/src/api/fmt/upper_hex.rs
 deleted file mode 100644
-index 5ad4557..0000000
 --- a/third_party/rust/packed_simd/src/api/fmt/upper_hex.rs
 +++ /dev/null
 @@ -1,54 +0,0 @@
@@ -8455,27 +9872,20 @@ index 5ad4557..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api/fmt.rs b/third_party/rust/packed_simd/src/api/fmt.rs
+diff --git a/third_party/rust/packed_simd/src/api/from.rs b/third_party/rust/packed_simd/src/api/from.rs
 deleted file mode 100644
-index f3f55c4..0000000
---- a/third_party/rust/packed_simd/src/api/fmt.rs
+--- a/third_party/rust/packed_simd/src/api/from.rs
 +++ /dev/null
-@@ -1,12 +0,0 @@
--//! Implements formatting APIs
+@@ -1,7 +0,0 @@
+-//! Implementations of the `From` and `Into` traits
 -
 -#[macro_use]
--mod debug;
+-mod from_array;
+-
 -#[macro_use]
--mod lower_hex;
--#[macro_use]
--mod upper_hex;
--#[macro_use]
--mod octal;
--#[macro_use]
--mod binary;
+-mod from_vector;
 diff --git a/third_party/rust/packed_simd/src/api/from/from_array.rs b/third_party/rust/packed_simd/src/api/from/from_array.rs
 deleted file mode 100644
-index 5c7801d..0000000
 --- a/third_party/rust/packed_simd/src/api/from/from_array.rs
 +++ /dev/null
 @@ -1,124 +0,0 @@
@@ -8605,7 +10015,6 @@ index 5c7801d..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/from/from_vector.rs b/third_party/rust/packed_simd/src/api/from/from_vector.rs
 deleted file mode 100644
-index 55f7001..0000000
 --- a/third_party/rust/packed_simd/src/api/from/from_vector.rs
 +++ /dev/null
 @@ -1,67 +0,0 @@
@@ -8676,22 +10085,8 @@ index 55f7001..0000000
 -        )*
 -    }
 -}
-diff --git a/third_party/rust/packed_simd/src/api/from.rs b/third_party/rust/packed_simd/src/api/from.rs
-deleted file mode 100644
-index c30c4d6..0000000
---- a/third_party/rust/packed_simd/src/api/from.rs
-+++ /dev/null
-@@ -1,7 +0,0 @@
--//! Implementations of the `From` and `Into` traits
--
--#[macro_use]
--mod from_array;
--
--#[macro_use]
--mod from_vector;
 diff --git a/third_party/rust/packed_simd/src/api/hash.rs b/third_party/rust/packed_simd/src/api/hash.rs
 deleted file mode 100644
-index ee80eff..0000000
 --- a/third_party/rust/packed_simd/src/api/hash.rs
 +++ /dev/null
 @@ -1,49 +0,0 @@
@@ -8744,9 +10139,72 @@ index ee80eff..0000000
 -        }
 -    };
 -}
+diff --git a/third_party/rust/packed_simd/src/api/into_bits.rs b/third_party/rust/packed_simd/src/api/into_bits.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/api/into_bits.rs
++++ /dev/null
+@@ -1,59 +0,0 @@
+-//! Implementation of `FromBits` and `IntoBits`.
+-
+-/// Safe lossless bitwise conversion from `T` to `Self`.
+-#[cfg_attr(doc_cfg, doc(cfg(feature = "into_bits")))]
+-pub trait FromBits<T>: crate::marker::Sized {
+-    /// Safe lossless bitwise transmute from `T` to `Self`.
+-    fn from_bits(t: T) -> Self;
+-}
+-
+-/// Safe lossless bitwise conversion from `Self` to `T`.
+-#[cfg_attr(doc_cfg, doc(cfg(feature = "into_bits")))]
+-pub trait IntoBits<T>: crate::marker::Sized {
+-    /// Safe lossless bitwise transmute from `self` to `T`.
+-    fn into_bits(self) -> T;
+-}
+-
+-/// `FromBits` implies `IntoBits`.
+-impl<T, U> IntoBits<U> for T
+-where
+-    U: FromBits<T>,
+-{
+-    #[inline]
+-    fn into_bits(self) -> U {
+-        debug_assert!(crate::mem::size_of::<Self>() == crate::mem::size_of::<U>());
+-        U::from_bits(self)
+-    }
+-}
+-
+-/// `FromBits` and `IntoBits` are reflexive
+-impl<T> FromBits<T> for T {
+-    #[inline]
+-    fn from_bits(t: Self) -> Self {
+-        t
+-    }
+-}
+-
+-#[macro_use]
+-mod macros;
+-
+-mod v16;
+-pub use self::v16::*;
+-
+-mod v32;
+-pub use self::v32::*;
+-
+-mod v64;
+-pub use self::v64::*;
+-
+-mod v128;
+-pub use self::v128::*;
+-
+-mod v256;
+-pub use self::v256::*;
+-
+-mod v512;
+-pub use self::v512::*;
+-
+-mod arch_specific;
+-pub use self::arch_specific::*;
 diff --git a/third_party/rust/packed_simd/src/api/into_bits/arch_specific.rs b/third_party/rust/packed_simd/src/api/into_bits/arch_specific.rs
 deleted file mode 100644
-index bfac915..0000000
 --- a/third_party/rust/packed_simd/src/api/into_bits/arch_specific.rs
 +++ /dev/null
 @@ -1,345 +0,0 @@
@@ -9097,7 +10555,6 @@ index bfac915..0000000
 -// FIXME: Implementations for the 512-bit wide vector types
 diff --git a/third_party/rust/packed_simd/src/api/into_bits/macros.rs b/third_party/rust/packed_simd/src/api/into_bits/macros.rs
 deleted file mode 100644
-index 265ab34..0000000
 --- a/third_party/rust/packed_simd/src/api/into_bits/macros.rs
 +++ /dev/null
 @@ -1,74 +0,0 @@
@@ -9177,7 +10634,6 @@ index 265ab34..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/into_bits/v128.rs b/third_party/rust/packed_simd/src/api/into_bits/v128.rs
 deleted file mode 100644
-index 639c09c..0000000
 --- a/third_party/rust/packed_simd/src/api/into_bits/v128.rs
 +++ /dev/null
 @@ -1,232 +0,0 @@
@@ -9415,7 +10871,6 @@ index 639c09c..0000000
 -// here
 diff --git a/third_party/rust/packed_simd/src/api/into_bits/v16.rs b/third_party/rust/packed_simd/src/api/into_bits/v16.rs
 deleted file mode 100644
-index e44d0e7..0000000
 --- a/third_party/rust/packed_simd/src/api/into_bits/v16.rs
 +++ /dev/null
 @@ -1,9 +0,0 @@
@@ -9430,7 +10885,6 @@ index e44d0e7..0000000
 -// note: m8x2 cannot be constructed from all i8x2 or u8x2 bit patterns
 diff --git a/third_party/rust/packed_simd/src/api/into_bits/v256.rs b/third_party/rust/packed_simd/src/api/into_bits/v256.rs
 deleted file mode 100644
-index e432bbb..0000000
 --- a/third_party/rust/packed_simd/src/api/into_bits/v256.rs
 +++ /dev/null
 @@ -1,232 +0,0 @@
@@ -9668,7 +11122,6 @@ index e432bbb..0000000
 -// here
 diff --git a/third_party/rust/packed_simd/src/api/into_bits/v32.rs b/third_party/rust/packed_simd/src/api/into_bits/v32.rs
 deleted file mode 100644
-index 5dba38a..0000000
 --- a/third_party/rust/packed_simd/src/api/into_bits/v32.rs
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -9687,7 +11140,6 @@ index 5dba38a..0000000
 -// note: m16x2 cannot be constructed from all m8x4 bit patterns
 diff --git a/third_party/rust/packed_simd/src/api/into_bits/v512.rs b/third_party/rust/packed_simd/src/api/into_bits/v512.rs
 deleted file mode 100644
-index f6e9bb8..0000000
 --- a/third_party/rust/packed_simd/src/api/into_bits/v512.rs
 +++ /dev/null
 @@ -1,232 +0,0 @@
@@ -9925,7 +11377,6 @@ index f6e9bb8..0000000
 -// here
 diff --git a/third_party/rust/packed_simd/src/api/into_bits/v64.rs b/third_party/rust/packed_simd/src/api/into_bits/v64.rs
 deleted file mode 100644
-index 5b065f1..0000000
 --- a/third_party/rust/packed_simd/src/api/into_bits/v64.rs
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -9947,74 +11398,83 @@ index 5b065f1..0000000
 -impl_from_bits!(u32x2[test_v64]: i8x8, u8x8, m8x8, i16x4, u16x4, m16x4, i32x2, f32x2, m32x2);
 -impl_from_bits!(f32x2[test_v64]: i8x8, u8x8, m8x8, i16x4, u16x4, m16x4, i32x2, u32x2, m32x2);
 -// note: m32x2 cannot be constructed from all m16x4 or m8x8 bit patterns
-diff --git a/third_party/rust/packed_simd/src/api/into_bits.rs b/third_party/rust/packed_simd/src/api/into_bits.rs
+diff --git a/third_party/rust/packed_simd/src/api/math.rs b/third_party/rust/packed_simd/src/api/math.rs
 deleted file mode 100644
-index 03fbe4b..0000000
---- a/third_party/rust/packed_simd/src/api/into_bits.rs
+--- a/third_party/rust/packed_simd/src/api/math.rs
 +++ /dev/null
-@@ -1,59 +0,0 @@
--//! Implementation of `FromBits` and `IntoBits`.
--
--/// Safe lossless bitwise conversion from `T` to `Self`.
--#[cfg_attr(doc_cfg, doc(cfg(feature = "into_bits")))]
--pub trait FromBits<T>: crate::marker::Sized {
--    /// Safe lossless bitwise transmute from `T` to `Self`.
--    fn from_bits(t: T) -> Self;
--}
--
--/// Safe lossless bitwise conversion from `Self` to `T`.
--#[cfg_attr(doc_cfg, doc(cfg(feature = "into_bits")))]
--pub trait IntoBits<T>: crate::marker::Sized {
--    /// Safe lossless bitwise transmute from `self` to `T`.
--    fn into_bits(self) -> T;
--}
--
--/// `FromBits` implies `IntoBits`.
--impl<T, U> IntoBits<U> for T
--where
--    U: FromBits<T>,
--{
--    #[inline]
--    fn into_bits(self) -> U {
--        debug_assert!(crate::mem::size_of::<Self>() == crate::mem::size_of::<U>());
--        U::from_bits(self)
--    }
--}
--
--/// `FromBits` and `IntoBits` are reflexive
--impl<T> FromBits<T> for T {
--    #[inline]
--    fn from_bits(t: Self) -> Self {
--        t
--    }
--}
+@@ -1,4 +0,0 @@
+-//! Implements vertical math operations
 -
 -#[macro_use]
--mod macros;
+-mod float;
+diff --git a/third_party/rust/packed_simd/src/api/math/float.rs b/third_party/rust/packed_simd/src/api/math/float.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/api/math/float.rs
++++ /dev/null
+@@ -1,61 +0,0 @@
+-//! Implements vertical floating-point math operations.
 -
--mod v16;
--pub use self::v16::*;
+-#[macro_use]
+-mod abs;
 -
--mod v32;
--pub use self::v32::*;
+-#[macro_use]
+-mod consts;
 -
--mod v64;
--pub use self::v64::*;
+-#[macro_use]
+-mod cos;
 -
--mod v128;
--pub use self::v128::*;
+-#[macro_use]
+-mod exp;
 -
--mod v256;
--pub use self::v256::*;
+-#[macro_use]
+-mod powf;
 -
--mod v512;
--pub use self::v512::*;
+-#[macro_use]
+-mod ln;
 -
--mod arch_specific;
--pub use self::arch_specific::*;
+-#[macro_use]
+-mod mul_add;
+-
+-#[macro_use]
+-mod mul_adde;
+-
+-#[macro_use]
+-mod recpre;
+-
+-#[macro_use]
+-mod rsqrte;
+-
+-#[macro_use]
+-mod sin;
+-
+-#[macro_use]
+-mod sqrt;
+-
+-#[macro_use]
+-mod sqrte;
+-
+-macro_rules! impl_float_category {
+-    ([$elem_ty:ident; $elem_count:expr]: $id:ident, $mask_ty:ident) => {
+-        impl $id {
+-            #[inline]
+-            pub fn is_nan(self) -> $mask_ty {
+-                self.ne(self)
+-            }
+-
+-            #[inline]
+-            pub fn is_infinite(self) -> $mask_ty {
+-                self.eq(Self::INFINITY) | self.eq(Self::NEG_INFINITY)
+-            }
+-
+-            #[inline]
+-            pub fn is_finite(self) -> $mask_ty {
+-                !(self.is_nan() | self.is_infinite())
+-            }
+-        }
+-    };
+-}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/abs.rs b/third_party/rust/packed_simd/src/api/math/float/abs.rs
 deleted file mode 100644
-index 1865bdb..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/abs.rs
 +++ /dev/null
 @@ -1,31 +0,0 @@
@@ -10051,7 +11511,6 @@ index 1865bdb..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/consts.rs b/third_party/rust/packed_simd/src/api/math/float/consts.rs
 deleted file mode 100644
-index 7f41acb..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/consts.rs
 +++ /dev/null
 @@ -1,74 +0,0 @@
@@ -10131,7 +11590,6 @@ index 7f41acb..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/cos.rs b/third_party/rust/packed_simd/src/api/math/float/cos.rs
 deleted file mode 100644
-index e5b8f46..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/cos.rs
 +++ /dev/null
 @@ -1,44 +0,0 @@
@@ -10181,7 +11639,6 @@ index e5b8f46..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/exp.rs b/third_party/rust/packed_simd/src/api/math/float/exp.rs
 deleted file mode 100644
-index e3356d8..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/exp.rs
 +++ /dev/null
 @@ -1,33 +0,0 @@
@@ -10220,7 +11677,6 @@ index e3356d8..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/ln.rs b/third_party/rust/packed_simd/src/api/math/float/ln.rs
 deleted file mode 100644
-index 5ceb917..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/ln.rs
 +++ /dev/null
 @@ -1,33 +0,0 @@
@@ -10259,7 +11715,6 @@ index 5ceb917..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/mul_add.rs b/third_party/rust/packed_simd/src/api/math/float/mul_add.rs
 deleted file mode 100644
-index 4b170ee..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/mul_add.rs
 +++ /dev/null
 @@ -1,44 +0,0 @@
@@ -10309,7 +11764,6 @@ index 4b170ee..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/mul_adde.rs b/third_party/rust/packed_simd/src/api/math/float/mul_adde.rs
 deleted file mode 100644
-index c5b2711..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/mul_adde.rs
 +++ /dev/null
 @@ -1,48 +0,0 @@
@@ -10363,7 +11817,6 @@ index c5b2711..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/powf.rs b/third_party/rust/packed_simd/src/api/math/float/powf.rs
 deleted file mode 100644
-index 83dc9ff..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/powf.rs
 +++ /dev/null
 @@ -1,36 +0,0 @@
@@ -10405,7 +11858,6 @@ index 83dc9ff..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/recpre.rs b/third_party/rust/packed_simd/src/api/math/float/recpre.rs
 deleted file mode 100644
-index 127f0b2..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/recpre.rs
 +++ /dev/null
 @@ -1,36 +0,0 @@
@@ -10447,7 +11899,6 @@ index 127f0b2..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/rsqrte.rs b/third_party/rust/packed_simd/src/api/math/float/rsqrte.rs
 deleted file mode 100644
-index c77977f..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/rsqrte.rs
 +++ /dev/null
 @@ -1,40 +0,0 @@
@@ -10493,7 +11944,6 @@ index c77977f..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/sin.rs b/third_party/rust/packed_simd/src/api/math/float/sin.rs
 deleted file mode 100644
-index 4990831..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/sin.rs
 +++ /dev/null
 @@ -1,50 +0,0 @@
@@ -10549,7 +11999,6 @@ index 4990831..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/sqrt.rs b/third_party/rust/packed_simd/src/api/math/float/sqrt.rs
 deleted file mode 100644
-index ae62412..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/sqrt.rs
 +++ /dev/null
 @@ -1,35 +0,0 @@
@@ -10590,7 +12039,6 @@ index ae62412..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/math/float/sqrte.rs b/third_party/rust/packed_simd/src/api/math/float/sqrte.rs
 deleted file mode 100644
-index f7ffad7..0000000
 --- a/third_party/rust/packed_simd/src/api/math/float/sqrte.rs
 +++ /dev/null
 @@ -1,44 +0,0 @@
@@ -10638,86 +12086,19 @@ index f7ffad7..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api/math/float.rs b/third_party/rust/packed_simd/src/api/math/float.rs
+diff --git a/third_party/rust/packed_simd/src/api/minimal.rs b/third_party/rust/packed_simd/src/api/minimal.rs
 deleted file mode 100644
-index c0ec46e..0000000
---- a/third_party/rust/packed_simd/src/api/math/float.rs
+--- a/third_party/rust/packed_simd/src/api/minimal.rs
 +++ /dev/null
-@@ -1,61 +0,0 @@
--//! Implements vertical floating-point math operations.
--
+@@ -1,6 +0,0 @@
 -#[macro_use]
--mod abs;
--
+-mod iuf;
 -#[macro_use]
--mod consts;
--
+-mod mask;
 -#[macro_use]
--mod cos;
--
--#[macro_use]
--mod exp;
--
--#[macro_use]
--mod powf;
--
--#[macro_use]
--mod ln;
--
--#[macro_use]
--mod mul_add;
--
--#[macro_use]
--mod mul_adde;
--
--#[macro_use]
--mod recpre;
--
--#[macro_use]
--mod rsqrte;
--
--#[macro_use]
--mod sin;
--
--#[macro_use]
--mod sqrt;
--
--#[macro_use]
--mod sqrte;
--
--macro_rules! impl_float_category {
--    ([$elem_ty:ident; $elem_count:expr]: $id:ident, $mask_ty:ident) => {
--        impl $id {
--            #[inline]
--            pub fn is_nan(self) -> $mask_ty {
--                self.ne(self)
--            }
--
--            #[inline]
--            pub fn is_infinite(self) -> $mask_ty {
--                self.eq(Self::INFINITY) | self.eq(Self::NEG_INFINITY)
--            }
--
--            #[inline]
--            pub fn is_finite(self) -> $mask_ty {
--                !(self.is_nan() | self.is_infinite())
--            }
--        }
--    };
--}
-diff --git a/third_party/rust/packed_simd/src/api/math.rs b/third_party/rust/packed_simd/src/api/math.rs
-deleted file mode 100644
-index e7a8d25..0000000
---- a/third_party/rust/packed_simd/src/api/math.rs
-+++ /dev/null
-@@ -1,4 +0,0 @@
--//! Implements vertical math operations
--
--#[macro_use]
--mod float;
+-mod ptr;
 diff --git a/third_party/rust/packed_simd/src/api/minimal/iuf.rs b/third_party/rust/packed_simd/src/api/minimal/iuf.rs
 deleted file mode 100644
-index a155ac1..0000000
 --- a/third_party/rust/packed_simd/src/api/minimal/iuf.rs
 +++ /dev/null
 @@ -1,169 +0,0 @@
@@ -10892,7 +12273,6 @@ index a155ac1..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/minimal/mask.rs b/third_party/rust/packed_simd/src/api/minimal/mask.rs
 deleted file mode 100644
-index a420060..0000000
 --- a/third_party/rust/packed_simd/src/api/minimal/mask.rs
 +++ /dev/null
 @@ -1,176 +0,0 @@
@@ -11074,7 +12454,6 @@ index a420060..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/minimal/ptr.rs b/third_party/rust/packed_simd/src/api/minimal/ptr.rs
 deleted file mode 100644
-index d9e47c9..0000000
 --- a/third_party/rust/packed_simd/src/api/minimal/ptr.rs
 +++ /dev/null
 @@ -1,1373 +0,0 @@
@@ -12451,21 +13830,45 @@ index d9e47c9..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api/minimal.rs b/third_party/rust/packed_simd/src/api/minimal.rs
+diff --git a/third_party/rust/packed_simd/src/api/ops.rs b/third_party/rust/packed_simd/src/api/ops.rs
 deleted file mode 100644
-index 840d9e3..0000000
---- a/third_party/rust/packed_simd/src/api/minimal.rs
+--- a/third_party/rust/packed_simd/src/api/ops.rs
 +++ /dev/null
-@@ -1,6 +0,0 @@
+@@ -1,32 +0,0 @@
+-//! Implementation of the `ops` traits
 -#[macro_use]
--mod iuf;
+-mod vector_mask_bitwise;
 -#[macro_use]
--mod mask;
+-mod scalar_mask_bitwise;
+-
 -#[macro_use]
--mod ptr;
+-mod vector_arithmetic;
+-#[macro_use]
+-mod scalar_arithmetic;
+-
+-#[macro_use]
+-mod vector_bitwise;
+-#[macro_use]
+-mod scalar_bitwise;
+-
+-#[macro_use]
+-mod vector_shifts;
+-#[macro_use]
+-mod scalar_shifts;
+-
+-#[macro_use]
+-mod vector_rotates;
+-
+-#[macro_use]
+-mod vector_neg;
+-
+-#[macro_use]
+-mod vector_int_min_max;
+-
+-#[macro_use]
+-mod vector_float_min_max;
 diff --git a/third_party/rust/packed_simd/src/api/ops/scalar_arithmetic.rs b/third_party/rust/packed_simd/src/api/ops/scalar_arithmetic.rs
 deleted file mode 100644
-index da1a203..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/scalar_arithmetic.rs
 +++ /dev/null
 @@ -1,203 +0,0 @@
@@ -12674,7 +14077,6 @@ index da1a203..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/scalar_bitwise.rs b/third_party/rust/packed_simd/src/api/ops/scalar_bitwise.rs
 deleted file mode 100644
-index 8821676..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/scalar_bitwise.rs
 +++ /dev/null
 @@ -1,162 +0,0 @@
@@ -12842,7 +14244,6 @@ index 8821676..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/scalar_mask_bitwise.rs b/third_party/rust/packed_simd/src/api/ops/scalar_mask_bitwise.rs
 deleted file mode 100644
-index 523a852..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/scalar_mask_bitwise.rs
 +++ /dev/null
 @@ -1,140 +0,0 @@
@@ -12988,7 +14389,6 @@ index 523a852..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/scalar_shifts.rs b/third_party/rust/packed_simd/src/api/ops/scalar_shifts.rs
 deleted file mode 100644
-index 4a7a096..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/scalar_shifts.rs
 +++ /dev/null
 @@ -1,106 +0,0 @@
@@ -13100,7 +14500,6 @@ index 4a7a096..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/vector_arithmetic.rs b/third_party/rust/packed_simd/src/api/ops/vector_arithmetic.rs
 deleted file mode 100644
-index 7057f52..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/vector_arithmetic.rs
 +++ /dev/null
 @@ -1,148 +0,0 @@
@@ -13254,7 +14653,6 @@ index 7057f52..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/vector_bitwise.rs b/third_party/rust/packed_simd/src/api/ops/vector_bitwise.rs
 deleted file mode 100644
-index 7be9603..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/vector_bitwise.rs
 +++ /dev/null
 @@ -1,129 +0,0 @@
@@ -13389,7 +14787,6 @@ index 7be9603..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/vector_float_min_max.rs b/third_party/rust/packed_simd/src/api/ops/vector_float_min_max.rs
 deleted file mode 100644
-index 8310667..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/vector_float_min_max.rs
 +++ /dev/null
 @@ -1,74 +0,0 @@
@@ -13469,7 +14866,6 @@ index 8310667..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/vector_int_min_max.rs b/third_party/rust/packed_simd/src/api/ops/vector_int_min_max.rs
 deleted file mode 100644
-index 36ea98e..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/vector_int_min_max.rs
 +++ /dev/null
 @@ -1,57 +0,0 @@
@@ -13532,7 +14928,6 @@ index 36ea98e..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/vector_mask_bitwise.rs b/third_party/rust/packed_simd/src/api/ops/vector_mask_bitwise.rs
 deleted file mode 100644
-index 295fc1c..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/vector_mask_bitwise.rs
 +++ /dev/null
 @@ -1,116 +0,0 @@
@@ -13654,7 +15049,6 @@ index 295fc1c..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/vector_neg.rs b/third_party/rust/packed_simd/src/api/ops/vector_neg.rs
 deleted file mode 100644
-index e2d91fd..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/vector_neg.rs
 +++ /dev/null
 @@ -1,43 +0,0 @@
@@ -13703,7 +15097,6 @@ index e2d91fd..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/vector_rotates.rs b/third_party/rust/packed_simd/src/api/ops/vector_rotates.rs
 deleted file mode 100644
-index 6c4bed7..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/vector_rotates.rs
 +++ /dev/null
 @@ -1,92 +0,0 @@
@@ -13801,7 +15194,6 @@ index 6c4bed7..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/ops/vector_shifts.rs b/third_party/rust/packed_simd/src/api/ops/vector_shifts.rs
 deleted file mode 100644
-index 8bb5ac2..0000000
 --- a/third_party/rust/packed_simd/src/api/ops/vector_shifts.rs
 +++ /dev/null
 @@ -1,106 +0,0 @@
@@ -13911,47 +15303,17 @@ index 8bb5ac2..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api/ops.rs b/third_party/rust/packed_simd/src/api/ops.rs
+diff --git a/third_party/rust/packed_simd/src/api/ptr.rs b/third_party/rust/packed_simd/src/api/ptr.rs
 deleted file mode 100644
-index f71c987..0000000
---- a/third_party/rust/packed_simd/src/api/ops.rs
+--- a/third_party/rust/packed_simd/src/api/ptr.rs
 +++ /dev/null
-@@ -1,32 +0,0 @@
--//! Implementation of the `ops` traits
--#[macro_use]
--mod vector_mask_bitwise;
--#[macro_use]
--mod scalar_mask_bitwise;
+@@ -1,4 +0,0 @@
+-//! Vector of pointers
 -
 -#[macro_use]
--mod vector_arithmetic;
--#[macro_use]
--mod scalar_arithmetic;
--
--#[macro_use]
--mod vector_bitwise;
--#[macro_use]
--mod scalar_bitwise;
--
--#[macro_use]
--mod vector_shifts;
--#[macro_use]
--mod scalar_shifts;
--
--#[macro_use]
--mod vector_rotates;
--
--#[macro_use]
--mod vector_neg;
--
--#[macro_use]
--mod vector_int_min_max;
--
--#[macro_use]
--mod vector_float_min_max;
+-mod gather_scatter;
 diff --git a/third_party/rust/packed_simd/src/api/ptr/gather_scatter.rs b/third_party/rust/packed_simd/src/api/ptr/gather_scatter.rs
 deleted file mode 100644
-index 374482a..0000000
 --- a/third_party/rust/packed_simd/src/api/ptr/gather_scatter.rs
 +++ /dev/null
 @@ -1,216 +0,0 @@
@@ -14171,19 +15533,25 @@ index 374482a..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api/ptr.rs b/third_party/rust/packed_simd/src/api/ptr.rs
+diff --git a/third_party/rust/packed_simd/src/api/reductions.rs b/third_party/rust/packed_simd/src/api/reductions.rs
 deleted file mode 100644
-index d2e523a..0000000
---- a/third_party/rust/packed_simd/src/api/ptr.rs
+--- a/third_party/rust/packed_simd/src/api/reductions.rs
 +++ /dev/null
-@@ -1,4 +0,0 @@
--//! Vector of pointers
+@@ -1,12 +0,0 @@
+-//! Reductions
 -
 -#[macro_use]
--mod gather_scatter;
+-mod float_arithmetic;
+-#[macro_use]
+-mod integer_arithmetic;
+-#[macro_use]
+-mod bitwise;
+-#[macro_use]
+-mod mask;
+-#[macro_use]
+-mod min_max;
 diff --git a/third_party/rust/packed_simd/src/api/reductions/bitwise.rs b/third_party/rust/packed_simd/src/api/reductions/bitwise.rs
 deleted file mode 100644
-index 5bad4f4..0000000
 --- a/third_party/rust/packed_simd/src/api/reductions/bitwise.rs
 +++ /dev/null
 @@ -1,151 +0,0 @@
@@ -14340,7 +15708,6 @@ index 5bad4f4..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/reductions/float_arithmetic.rs b/third_party/rust/packed_simd/src/api/reductions/float_arithmetic.rs
 deleted file mode 100644
-index 9dc8783..0000000
 --- a/third_party/rust/packed_simd/src/api/reductions/float_arithmetic.rs
 +++ /dev/null
 @@ -1,313 +0,0 @@
@@ -14659,7 +16026,6 @@ index 9dc8783..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/reductions/integer_arithmetic.rs b/third_party/rust/packed_simd/src/api/reductions/integer_arithmetic.rs
 deleted file mode 100644
-index e99e6cb..0000000
 --- a/third_party/rust/packed_simd/src/api/reductions/integer_arithmetic.rs
 +++ /dev/null
 @@ -1,193 +0,0 @@
@@ -14858,7 +16224,6 @@ index e99e6cb..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/reductions/mask.rs b/third_party/rust/packed_simd/src/api/reductions/mask.rs
 deleted file mode 100644
-index 0dd6a84..0000000
 --- a/third_party/rust/packed_simd/src/api/reductions/mask.rs
 +++ /dev/null
 @@ -1,89 +0,0 @@
@@ -14953,7 +16318,6 @@ index 0dd6a84..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/reductions/min_max.rs b/third_party/rust/packed_simd/src/api/reductions/min_max.rs
 deleted file mode 100644
-index a3ce13a..0000000
 --- a/third_party/rust/packed_simd/src/api/reductions/min_max.rs
 +++ /dev/null
 @@ -1,360 +0,0 @@
@@ -15317,27 +16681,8 @@ index a3ce13a..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api/reductions.rs b/third_party/rust/packed_simd/src/api/reductions.rs
-deleted file mode 100644
-index 54d2f0c..0000000
---- a/third_party/rust/packed_simd/src/api/reductions.rs
-+++ /dev/null
-@@ -1,12 +0,0 @@
--//! Reductions
--
--#[macro_use]
--mod float_arithmetic;
--#[macro_use]
--mod integer_arithmetic;
--#[macro_use]
--mod bitwise;
--#[macro_use]
--mod mask;
--#[macro_use]
--mod min_max;
 diff --git a/third_party/rust/packed_simd/src/api/select.rs b/third_party/rust/packed_simd/src/api/select.rs
 deleted file mode 100644
-index daf6294..0000000
 --- a/third_party/rust/packed_simd/src/api/select.rs
 +++ /dev/null
 @@ -1,73 +0,0 @@
@@ -15416,7 +16761,6 @@ index daf6294..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/shuffle.rs b/third_party/rust/packed_simd/src/api/shuffle.rs
 deleted file mode 100644
-index 1c17bd7..0000000
 --- a/third_party/rust/packed_simd/src/api/shuffle.rs
 +++ /dev/null
 @@ -1,184 +0,0 @@
@@ -15606,7 +16950,6 @@ index 1c17bd7..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/shuffle1_dyn.rs b/third_party/rust/packed_simd/src/api/shuffle1_dyn.rs
 deleted file mode 100644
-index 64536be..0000000
 --- a/third_party/rust/packed_simd/src/api/shuffle1_dyn.rs
 +++ /dev/null
 @@ -1,159 +0,0 @@
@@ -15769,9 +17112,20 @@ index 64536be..0000000
 -        }
 -    };
 -}
+diff --git a/third_party/rust/packed_simd/src/api/slice.rs b/third_party/rust/packed_simd/src/api/slice.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/api/slice.rs
++++ /dev/null
+@@ -1,7 +0,0 @@
+-//! Slice from/to methods
+-
+-#[macro_use]
+-mod from_slice;
+-
+-#[macro_use]
+-mod write_to_slice;
 diff --git a/third_party/rust/packed_simd/src/api/slice/from_slice.rs b/third_party/rust/packed_simd/src/api/slice/from_slice.rs
 deleted file mode 100644
-index cafd6f8..0000000
 --- a/third_party/rust/packed_simd/src/api/slice/from_slice.rs
 +++ /dev/null
 @@ -1,202 +0,0 @@
@@ -15979,7 +17333,6 @@ index cafd6f8..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/api/slice/write_to_slice.rs b/third_party/rust/packed_simd/src/api/slice/write_to_slice.rs
 deleted file mode 100644
-index 5abd491..0000000
 --- a/third_party/rust/packed_simd/src/api/slice/write_to_slice.rs
 +++ /dev/null
 @@ -1,196 +0,0 @@
@@ -16179,22 +17532,8 @@ index 5abd491..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api/slice.rs b/third_party/rust/packed_simd/src/api/slice.rs
-deleted file mode 100644
-index 526b848..0000000
---- a/third_party/rust/packed_simd/src/api/slice.rs
-+++ /dev/null
-@@ -1,7 +0,0 @@
--//! Slice from/to methods
--
--#[macro_use]
--mod from_slice;
--
--#[macro_use]
--mod write_to_slice;
 diff --git a/third_party/rust/packed_simd/src/api/swap_bytes.rs b/third_party/rust/packed_simd/src/api/swap_bytes.rs
 deleted file mode 100644
-index 4649ed6..0000000
 --- a/third_party/rust/packed_simd/src/api/swap_bytes.rs
 +++ /dev/null
 @@ -1,192 +0,0 @@
@@ -16390,323 +17729,75 @@ index 4649ed6..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/api.rs b/third_party/rust/packed_simd/src/api.rs
+diff --git a/third_party/rust/packed_simd/src/codegen.rs b/third_party/rust/packed_simd/src/codegen.rs
 deleted file mode 100644
-index aa1403e..0000000
---- a/third_party/rust/packed_simd/src/api.rs
+--- a/third_party/rust/packed_simd/src/codegen.rs
 +++ /dev/null
-@@ -1,308 +0,0 @@
--//! Implements the Simd<[T; N]> APIs
+@@ -1,62 +0,0 @@
+-//! Code-generation utilities
 -
--#[macro_use]
--mod bitmask;
--pub(crate) mod cast;
--#[macro_use]
--mod cmp;
--#[macro_use]
--mod default;
--#[macro_use]
--mod fmt;
--#[macro_use]
--mod from;
--#[macro_use]
--mod hash;
--#[macro_use]
--mod math;
--#[macro_use]
--mod minimal;
--#[macro_use]
--mod ops;
--#[macro_use]
--mod ptr;
--#[macro_use]
--mod reductions;
--#[macro_use]
--mod select;
--#[macro_use]
--mod shuffle;
--#[macro_use]
--mod shuffle1_dyn;
--#[macro_use]
--mod slice;
--#[macro_use]
--mod swap_bytes;
--#[macro_use]
--mod bit_manip;
+-pub(crate) mod bit_manip;
+-pub(crate) mod llvm;
+-pub(crate) mod math;
+-pub(crate) mod reductions;
+-pub(crate) mod shuffle;
+-pub(crate) mod shuffle1_dyn;
+-pub(crate) mod swap_bytes;
 -
--#[cfg(feature = "into_bits")]
--pub(crate) mod into_bits;
+-macro_rules! impl_simd_array {
+-    ([$elem_ty:ident; $elem_count:expr]:
+-     $tuple_id:ident | $($elem_tys:ident),*) => {
+-        #[derive(Copy, Clone)]
+-        #[repr(simd)]
+-        pub struct $tuple_id($(pub(crate) $elem_tys),*);
+-        //^^^^^^^ leaked through SimdArray
 -
--macro_rules! impl_i {
--    ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident
--     | $ielem_ty:ident, $ibitmask_ty:ident | $test_tt:tt | $($elem_ids:ident),*
--     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
--        impl_minimal_iuf!([$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--                          | $($elem_ids),* | $(#[$doc])*);
--        impl_ops_vector_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_scalar_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_bitwise!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (!(0 as $elem_ty), 0)
--        );
--        impl_ops_scalar_bitwise!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (!(0 as $elem_ty), 0)
--        );
--        impl_ops_vector_shifts!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_scalar_shifts!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_rotates!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_neg!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_int_min_max!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt
--        );
--        impl_reduction_integer_arithmetic!(
--            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--        );
--        impl_reduction_min_max!(
--            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--        );
--        impl_reduction_bitwise!(
--            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--            | (|x|{ x as $elem_ty }) | (!(0 as $elem_ty), 0)
--        );
--        impl_fmt_debug!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_lower_hex!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_upper_hex!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_octal!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_binary!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_from_array!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (1, 1));
--        impl_from_vectors!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*
--        );
--        impl_default!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_hash!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_swap_bytes!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_bit_manip!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_partial_eq!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1)
--        );
--        impl_cmp_eq!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
--        impl_cmp_vertical!(
--            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, false, (1, 0) | $test_tt
--        );
--        impl_cmp_partial_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
--        impl_bitmask!($tuple_id | $ibitmask_ty | (-1, 0) | $test_tt);
+-        impl crate::sealed::Seal for [$elem_ty; $elem_count] {}
 -
--        test_select!($elem_ty, $mask_ty, $tuple_id, (1, 2) | $test_tt);
--        test_cmp_partial_ord_int!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-        impl crate::sealed::SimdArray for [$elem_ty; $elem_count] {
+-            type Tuple = $tuple_id;
+-            type T = $elem_ty;
+-            const N: usize = $elem_count;
+-            type NT = [u32; $elem_count];
+-        }
+-
+-        impl crate::sealed::Seal for $tuple_id {}
+-        impl crate::sealed::Simd for $tuple_id {
+-            type Element = $elem_ty;
+-            const LANES: usize = $elem_count;
+-            type LanesType = [u32; $elem_count];
+-        }
+-
 -    }
 -}
 -
--macro_rules! impl_u {
--    ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident
--     | $ielem_ty:ident, $ibitmask_ty:ident | $test_tt:tt | $($elem_ids:ident),*
--     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
--        impl_minimal_iuf!([$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--                          | $($elem_ids),* | $(#[$doc])*);
--        impl_ops_vector_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_scalar_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_bitwise!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (!(0 as $elem_ty), 0)
--        );
--        impl_ops_scalar_bitwise!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (!(0 as $elem_ty), 0)
--        );
--        impl_ops_vector_shifts!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_scalar_shifts!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_rotates!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_int_min_max!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt
--        );
--        impl_reduction_integer_arithmetic!(
--            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--        );
--        impl_reduction_min_max!(
--            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--        );
--        impl_reduction_bitwise!(
--            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--            | (|x|{ x as $elem_ty }) | (!(0 as $elem_ty), 0)
--        );
--        impl_fmt_debug!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_lower_hex!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_upper_hex!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_octal!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_binary!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_from_array!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (1, 1));
--        impl_from_vectors!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*
--        );
--        impl_default!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_hash!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_swap_bytes!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_bit_manip!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_partial_eq!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (1, 0)
--        );
--        impl_cmp_eq!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
--        impl_cmp_vertical!(
--            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, false, (1, 0) | $test_tt
--        );
--        impl_cmp_partial_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
--        impl_bitmask!($tuple_id | $ibitmask_ty | ($ielem_ty::max_value(), 0) |
--                      $test_tt);
+-pub(crate) mod pointer_sized_int;
 -
--        test_select!($elem_ty, $mask_ty, $tuple_id, (1, 2) | $test_tt);
--        test_cmp_partial_ord_int!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--    }
--}
+-pub(crate) mod v16;
+-pub(crate) use self::v16::*;
 -
--macro_rules! impl_f {
--    ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident
--     | $ielem_ty:ident | $test_tt:tt | $($elem_ids:ident),*
--     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
--        impl_minimal_iuf!([$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--                          | $($elem_ids),* | $(#[$doc])*);
--        impl_ops_vector_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_scalar_arithmetic!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_neg!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_ops_vector_float_min_max!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt
--        );
--        impl_reduction_float_arithmetic!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_reduction_min_max!(
--            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--        );
--        impl_fmt_debug!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_from_array!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (1., 1.));
--        impl_from_vectors!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*
--        );
--        impl_default!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_partial_eq!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (1., 0.)
--        );
--        impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+-pub(crate) mod v32;
+-pub(crate) use self::v32::*;
 -
--        impl_float_consts!([$elem_ty; $elem_n]: $tuple_id);
--        impl_float_category!([$elem_ty; $elem_n]: $tuple_id, $mask_ty);
+-pub(crate) mod v64;
+-pub(crate) use self::v64::*;
 -
--        // floating-point math
--        impl_math_float_abs!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_cos!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_exp!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_ln!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_mul_add!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_mul_adde!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_powf!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_recpre!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_rsqrte!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_sin!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_sqrt!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_math_float_sqrte!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_vertical!(
--            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, false, (1., 0.)
--                | $test_tt
--        );
+-pub(crate) mod v128;
+-pub(crate) use self::v128::*;
 -
--        test_select!($elem_ty, $mask_ty, $tuple_id, (1., 2.) | $test_tt);
--        test_reduction_float_min_max!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt
--        );
--        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--    }
--}
+-pub(crate) mod v256;
+-pub(crate) use self::v256::*;
 -
--macro_rules! impl_m {
--    ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident
--     | $ielem_ty:ident, $ibitmask_ty:ident
--     | $test_tt:tt | $($elem_ids:ident),* | From: $($from_vec_ty:ident),*
--     | $(#[$doc:meta])*) => {
--        impl_minimal_mask!(
--            [$elem_ty; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--            | $($elem_ids),* | $(#[$doc])*
--        );
--        impl_ops_vector_mask_bitwise!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (true, false)
--        );
--        impl_ops_scalar_mask_bitwise!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (true, false)
--        );
--        impl_reduction_bitwise!(
--            [bool; $elem_n]: $tuple_id | $ielem_ty | $test_tt
--                | (|x|{ x != 0 }) | (true, false)
--        );
--        impl_reduction_mask!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_fmt_debug!([bool; $elem_n]: $tuple_id | $test_tt);
--        impl_from_array!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt
--            | (crate::$elem_ty::new(true), true)
--        );
--        impl_from_vectors!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*
--        );
--        impl_default!([bool; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_partial_eq!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (true, false)
--        );
--        impl_cmp_eq!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (true, false)
--        );
--        impl_cmp_vertical!(
--            [$elem_ty; $elem_n]: $tuple_id, $tuple_id, true, (true, false)
--            | $test_tt
--        );
--        impl_select!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_partial_ord!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_cmp_ord!(
--            [$elem_ty; $elem_n]: $tuple_id | $test_tt | (false, true)
--        );
--        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        impl_bitmask!($tuple_id | $ibitmask_ty | (true, false) | $test_tt);
+-pub(crate) mod v512;
+-pub(crate) use self::v512::*;
 -
--        test_cmp_partial_ord_mask!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--        test_shuffle1_dyn_mask!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
--    }
--}
+-pub(crate) mod vSize;
+-pub(crate) use self::vSize::*;
 -
--macro_rules! impl_const_p {
--    ([$elem_ty:ty; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident,
--     $usize_ty:ident, $isize_ty:ident
--     | $test_tt:tt | $($elem_ids:ident),*
--     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
--        impl_minimal_p!(
--            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, $usize_ty, $isize_ty
--                | ref_ | $test_tt | $($elem_ids),*
--                | (1 as $elem_ty, 0 as $elem_ty) | $(#[$doc])*
--        );
--        impl_ptr_read!([$elem_ty; $elem_n]: $tuple_id, $mask_ty | $test_tt);
--    }
--}
--
--macro_rules! impl_mut_p {
--    ([$elem_ty:ty; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident,
--     $usize_ty:ident, $isize_ty:ident
--     | $test_tt:tt | $($elem_ids:ident),*
--     | From: $($from_vec_ty:ident),* | $(#[$doc:meta])*) => {
--        impl_minimal_p!(
--            [$elem_ty; $elem_n]: $tuple_id, $mask_ty, $usize_ty, $isize_ty
--                | ref_mut_ | $test_tt | $($elem_ids),*
--                | (1 as $elem_ty, 0 as $elem_ty) | $(#[$doc])*
--        );
--        impl_ptr_read!([$elem_ty; $elem_n]: $tuple_id, $mask_ty | $test_tt);
--        impl_ptr_write!([$elem_ty; $elem_n]: $tuple_id, $mask_ty | $test_tt);
--    }
--}
+-pub(crate) mod vPtr;
+-pub(crate) use self::vPtr::*;
 diff --git a/third_party/rust/packed_simd/src/codegen/bit_manip.rs b/third_party/rust/packed_simd/src/codegen/bit_manip.rs
 deleted file mode 100644
-index 32d8d71..0000000
 --- a/third_party/rust/packed_simd/src/codegen/bit_manip.rs
 +++ /dev/null
 @@ -1,347 +0,0 @@
@@ -17059,7 +18150,6 @@ index 32d8d71..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/llvm.rs b/third_party/rust/packed_simd/src/codegen/llvm.rs
 deleted file mode 100644
-index bb482fa..0000000
 --- a/third_party/rust/packed_simd/src/codegen/llvm.rs
 +++ /dev/null
 @@ -1,122 +0,0 @@
@@ -17185,9 +18275,39 @@ index bb482fa..0000000
 -
 -    pub(crate) fn simd_bitmask<T, U>(value: T) -> U;
 -}
+diff --git a/third_party/rust/packed_simd/src/codegen/math.rs b/third_party/rust/packed_simd/src/codegen/math.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/codegen/math.rs
++++ /dev/null
+@@ -1,3 +0,0 @@
+-//! Vertical math operations
+-
+-pub(crate) mod float;
+diff --git a/third_party/rust/packed_simd/src/codegen/math/float.rs b/third_party/rust/packed_simd/src/codegen/math/float.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/codegen/math/float.rs
++++ /dev/null
+@@ -1,18 +0,0 @@
+-//! Vertical floating-point math operations.
+-#![allow(clippy::useless_transmute)]
+-
+-#[macro_use]
+-pub(crate) mod macros;
+-pub(crate) mod abs;
+-pub(crate) mod cos;
+-pub(crate) mod cos_pi;
+-pub(crate) mod exp;
+-pub(crate) mod ln;
+-pub(crate) mod mul_add;
+-pub(crate) mod mul_adde;
+-pub(crate) mod powf;
+-pub(crate) mod sin;
+-pub(crate) mod sin_cos_pi;
+-pub(crate) mod sin_pi;
+-pub(crate) mod sqrt;
+-pub(crate) mod sqrte;
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/abs.rs b/third_party/rust/packed_simd/src/codegen/math/float/abs.rs
 deleted file mode 100644
-index 34aacc2..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/abs.rs
 +++ /dev/null
 @@ -1,103 +0,0 @@
@@ -17296,7 +18416,6 @@ index 34aacc2..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/cos.rs b/third_party/rust/packed_simd/src/codegen/math/float/cos.rs
 deleted file mode 100644
-index dec390c..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/cos.rs
 +++ /dev/null
 @@ -1,103 +0,0 @@
@@ -17405,7 +18524,6 @@ index dec390c..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/cos_pi.rs b/third_party/rust/packed_simd/src/codegen/math/float/cos_pi.rs
 deleted file mode 100644
-index e283280..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/cos_pi.rs
 +++ /dev/null
 @@ -1,87 +0,0 @@
@@ -17498,7 +18616,6 @@ index e283280..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/exp.rs b/third_party/rust/packed_simd/src/codegen/math/float/exp.rs
 deleted file mode 100644
-index a7b2058..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/exp.rs
 +++ /dev/null
 @@ -1,112 +0,0 @@
@@ -17616,7 +18733,6 @@ index a7b2058..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/ln.rs b/third_party/rust/packed_simd/src/codegen/math/float/ln.rs
 deleted file mode 100644
-index a5e38cb..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/ln.rs
 +++ /dev/null
 @@ -1,112 +0,0 @@
@@ -17734,7 +18850,6 @@ index a5e38cb..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/macros.rs b/third_party/rust/packed_simd/src/codegen/math/float/macros.rs
 deleted file mode 100644
-index 8daee1a..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/macros.rs
 +++ /dev/null
 @@ -1,470 +0,0 @@
@@ -18210,7 +19325,6 @@ index 8daee1a..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/mul_add.rs b/third_party/rust/packed_simd/src/codegen/math/float/mul_add.rs
 deleted file mode 100644
-index d37f30f..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/mul_add.rs
 +++ /dev/null
 @@ -1,109 +0,0 @@
@@ -18325,7 +19439,6 @@ index d37f30f..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/mul_adde.rs b/third_party/rust/packed_simd/src/codegen/math/float/mul_adde.rs
 deleted file mode 100644
-index c0baeac..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/mul_adde.rs
 +++ /dev/null
 @@ -1,60 +0,0 @@
@@ -18391,7 +19504,6 @@ index c0baeac..0000000
 -impl_mul_adde!(f64x8: fmuladd_v8f64);
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/powf.rs b/third_party/rust/packed_simd/src/codegen/math/float/powf.rs
 deleted file mode 100644
-index 89ca52e..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/powf.rs
 +++ /dev/null
 @@ -1,112 +0,0 @@
@@ -18509,7 +19621,6 @@ index 89ca52e..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/sin.rs b/third_party/rust/packed_simd/src/codegen/math/float/sin.rs
 deleted file mode 100644
-index d881415..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/sin.rs
 +++ /dev/null
 @@ -1,103 +0,0 @@
@@ -18618,7 +19729,6 @@ index d881415..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/sin_cos_pi.rs b/third_party/rust/packed_simd/src/codegen/math/float/sin_cos_pi.rs
 deleted file mode 100644
-index b283d11..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/sin_cos_pi.rs
 +++ /dev/null
 @@ -1,188 +0,0 @@
@@ -18812,7 +19922,6 @@ index b283d11..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/sin_pi.rs b/third_party/rust/packed_simd/src/codegen/math/float/sin_pi.rs
 deleted file mode 100644
-index 0c8f6bb..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/sin_pi.rs
 +++ /dev/null
 @@ -1,87 +0,0 @@
@@ -18905,7 +20014,6 @@ index 0c8f6bb..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/sqrt.rs b/third_party/rust/packed_simd/src/codegen/math/float/sqrt.rs
 deleted file mode 100644
-index 67bb0a2..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/sqrt.rs
 +++ /dev/null
 @@ -1,103 +0,0 @@
@@ -19014,7 +20122,6 @@ index 67bb0a2..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/math/float/sqrte.rs b/third_party/rust/packed_simd/src/codegen/math/float/sqrte.rs
 deleted file mode 100644
-index 58a1de1..0000000
 --- a/third_party/rust/packed_simd/src/codegen/math/float/sqrte.rs
 +++ /dev/null
 @@ -1,67 +0,0 @@
@@ -19085,42 +20192,8 @@ index 58a1de1..0000000
 -        impl_unary!(f64x8[g]: simd_fsqrt);
 -    }
 -}
-diff --git a/third_party/rust/packed_simd/src/codegen/math/float.rs b/third_party/rust/packed_simd/src/codegen/math/float.rs
-deleted file mode 100644
-index ffbf18b..0000000
---- a/third_party/rust/packed_simd/src/codegen/math/float.rs
-+++ /dev/null
-@@ -1,18 +0,0 @@
--//! Vertical floating-point math operations.
--#![allow(clippy::useless_transmute)]
--
--#[macro_use]
--pub(crate) mod macros;
--pub(crate) mod abs;
--pub(crate) mod cos;
--pub(crate) mod cos_pi;
--pub(crate) mod exp;
--pub(crate) mod ln;
--pub(crate) mod mul_add;
--pub(crate) mod mul_adde;
--pub(crate) mod powf;
--pub(crate) mod sin;
--pub(crate) mod sin_cos_pi;
--pub(crate) mod sin_pi;
--pub(crate) mod sqrt;
--pub(crate) mod sqrte;
-diff --git a/third_party/rust/packed_simd/src/codegen/math.rs b/third_party/rust/packed_simd/src/codegen/math.rs
-deleted file mode 100644
-index 9a0ea7a..0000000
---- a/third_party/rust/packed_simd/src/codegen/math.rs
-+++ /dev/null
-@@ -1,3 +0,0 @@
--//! Vertical math operations
--
--pub(crate) mod float;
 diff --git a/third_party/rust/packed_simd/src/codegen/pointer_sized_int.rs b/third_party/rust/packed_simd/src/codegen/pointer_sized_int.rs
 deleted file mode 100644
-index 55cbc29..0000000
 --- a/third_party/rust/packed_simd/src/codegen/pointer_sized_int.rs
 +++ /dev/null
 @@ -1,28 +0,0 @@
@@ -19152,9 +20225,88 @@ index 55cbc29..0000000
 -        compile_error!("unsupported target_pointer_width");
 -    }
 -}
+diff --git a/third_party/rust/packed_simd/src/codegen/reductions.rs b/third_party/rust/packed_simd/src/codegen/reductions.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/codegen/reductions.rs
++++ /dev/null
+@@ -1,1 +0,0 @@
+-pub(crate) mod mask;
+diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/codegen/reductions/mask.rs
++++ /dev/null
+@@ -1,69 +0,0 @@
+-//! Code generation workaround for `all()` mask horizontal reduction.
+-//!
+-//! Works around [LLVM bug 36702].
+-//!
+-//! [LLVM bug 36702]: https://bugs.llvm.org/show_bug.cgi?id=36702
+-#![allow(unused_macros)]
+-
+-use crate::*;
+-
+-pub(crate) trait All: crate::marker::Sized {
+-    unsafe fn all(self) -> bool;
+-}
+-
+-pub(crate) trait Any: crate::marker::Sized {
+-    unsafe fn any(self) -> bool;
+-}
+-
+-#[macro_use]
+-mod fallback_impl;
+-
+-cfg_if! {
+-    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+-        #[macro_use]
+-        mod x86;
+-    } else if #[cfg(all(target_arch = "arm", target_feature = "v7",
+-                        target_feature = "neon",
+-                        any(feature = "core_arch", libcore_neon)))] {
+-        #[macro_use]
+-        mod arm;
+-    } else if #[cfg(all(target_arch = "aarch64", target_feature = "neon"))] {
+-        #[macro_use]
+-        mod aarch64;
+-    } else {
+-        #[macro_use]
+-        mod fallback;
+-    }
+-}
+-
+-impl_mask_reductions!(m8x2);
+-impl_mask_reductions!(m8x4);
+-impl_mask_reductions!(m8x8);
+-impl_mask_reductions!(m8x16);
+-impl_mask_reductions!(m8x32);
+-impl_mask_reductions!(m8x64);
+-
+-impl_mask_reductions!(m16x2);
+-impl_mask_reductions!(m16x4);
+-impl_mask_reductions!(m16x8);
+-impl_mask_reductions!(m16x16);
+-impl_mask_reductions!(m16x32);
+-
+-impl_mask_reductions!(m32x2);
+-impl_mask_reductions!(m32x4);
+-impl_mask_reductions!(m32x8);
+-impl_mask_reductions!(m32x16);
+-
+-// FIXME: 64-bit single element vector
+-// impl_mask_reductions!(m64x1);
+-impl_mask_reductions!(m64x2);
+-impl_mask_reductions!(m64x4);
+-impl_mask_reductions!(m64x8);
+-
+-impl_mask_reductions!(m128x1);
+-impl_mask_reductions!(m128x2);
+-impl_mask_reductions!(m128x4);
+-
+-impl_mask_reductions!(msizex2);
+-impl_mask_reductions!(msizex4);
+-impl_mask_reductions!(msizex8);
 diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/aarch64.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/aarch64.rs
 deleted file mode 100644
-index b2db52c..0000000
 --- a/third_party/rust/packed_simd/src/codegen/reductions/mask/aarch64.rs
 +++ /dev/null
 @@ -1,81 +0,0 @@
@@ -19241,7 +20393,6 @@ index b2db52c..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/arm.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/arm.rs
 deleted file mode 100644
-index 41c3cbc..0000000
 --- a/third_party/rust/packed_simd/src/codegen/reductions/mask/arm.rs
 +++ /dev/null
 @@ -1,56 +0,0 @@
@@ -19303,7 +20454,6 @@ index 41c3cbc..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/fallback.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/fallback.rs
 deleted file mode 100644
-index 4c377a6..0000000
 --- a/third_party/rust/packed_simd/src/codegen/reductions/mask/fallback.rs
 +++ /dev/null
 @@ -1,8 +0,0 @@
@@ -19317,7 +20467,6 @@ index 4c377a6..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/fallback_impl.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/fallback_impl.rs
 deleted file mode 100644
-index 0d246e2..0000000
 --- a/third_party/rust/packed_simd/src/codegen/reductions/mask/fallback_impl.rs
 +++ /dev/null
 @@ -1,237 +0,0 @@
@@ -19558,266 +20707,8 @@ index 0d246e2..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx.rs
-deleted file mode 100644
-index 61f352d..0000000
---- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx.rs
-+++ /dev/null
-@@ -1,95 +0,0 @@
--//! Mask reductions implementation for `x86` and `x86_64` targets with `AVX`
--
--/// `x86`/`x86_64` 256-bit `AVX` implementation
--/// FIXME: it might be faster here to do two `_mm_movmask_epi8`
--#[cfg(target_feature = "avx")]
--macro_rules! x86_m8x32_avx_impl {
--    ($id:ident) => {
--        impl All for $id {
--            #[inline]
--            #[target_feature(enable = "avx")]
--            unsafe fn all(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm256_testc_si256;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm256_testc_si256;
--                _mm256_testc_si256(crate::mem::transmute(self), crate::mem::transmute($id::splat(true))) != 0
--            }
--        }
--        impl Any for $id {
--            #[inline]
--            #[target_feature(enable = "avx")]
--            unsafe fn any(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm256_testz_si256;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm256_testz_si256;
--                _mm256_testz_si256(crate::mem::transmute(self), crate::mem::transmute(self)) == 0
--            }
--        }
--    };
--}
--
--/// `x86`/`x86_64` 256-bit m32x8 `AVX` implementation
--macro_rules! x86_m32x8_avx_impl {
--    ($id:ident) => {
--        impl All for $id {
--            #[inline]
--            #[target_feature(enable = "sse")]
--            unsafe fn all(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm256_movemask_ps;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm256_movemask_ps;
--                // _mm256_movemask_ps(a) creates a 8bit mask containing the
--                // most significant bit of each lane of `a`. If all bits are
--                // set, then all 8 lanes of the mask are true.
--                _mm256_movemask_ps(crate::mem::transmute(self)) == 0b_1111_1111_i32
--            }
--        }
--        impl Any for $id {
--            #[inline]
--            #[target_feature(enable = "sse")]
--            unsafe fn any(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm256_movemask_ps;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm256_movemask_ps;
--
--                _mm256_movemask_ps(crate::mem::transmute(self)) != 0
--            }
--        }
--    };
--}
--
--/// `x86`/`x86_64` 256-bit m64x4 `AVX` implementation
--macro_rules! x86_m64x4_avx_impl {
--    ($id:ident) => {
--        impl All for $id {
--            #[inline]
--            #[target_feature(enable = "sse")]
--            unsafe fn all(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm256_movemask_pd;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm256_movemask_pd;
--                // _mm256_movemask_pd(a) creates a 4bit mask containing the
--                // most significant bit of each lane of `a`. If all bits are
--                // set, then all 4 lanes of the mask are true.
--                _mm256_movemask_pd(crate::mem::transmute(self)) == 0b_1111_i32
--            }
--        }
--        impl Any for $id {
--            #[inline]
--            #[target_feature(enable = "sse")]
--            unsafe fn any(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm256_movemask_pd;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm256_movemask_pd;
--
--                _mm256_movemask_pd(crate::mem::transmute(self)) != 0
--            }
--        }
--    };
--}
-diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx2.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx2.rs
-deleted file mode 100644
-index d37d023..0000000
---- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx2.rs
-+++ /dev/null
-@@ -1,35 +0,0 @@
--//! Mask reductions implementation for `x86` and `x86_64` targets with `AVX2`.
--#![allow(unused)]
--
--/// x86/x86_64 256-bit m8x32 AVX2 implementation
--macro_rules! x86_m8x32_avx2_impl {
--    ($id:ident) => {
--        impl All for $id {
--            #[inline]
--            #[target_feature(enable = "sse2")]
--            unsafe fn all(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm256_movemask_epi8;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm256_movemask_epi8;
--                // _mm256_movemask_epi8(a) creates a 32bit mask containing the
--                // most significant bit of each byte of `a`. If all
--                // bits are set, then all 32 lanes of the mask are
--                // true.
--                _mm256_movemask_epi8(crate::mem::transmute(self)) == -1_i32
--            }
--        }
--        impl Any for $id {
--            #[inline]
--            #[target_feature(enable = "sse2")]
--            unsafe fn any(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm256_movemask_epi8;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm256_movemask_epi8;
--
--                _mm256_movemask_epi8(crate::mem::transmute(self)) != 0
--            }
--        }
--    };
--}
-diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse.rs
-deleted file mode 100644
-index e0c9aee..0000000
---- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse.rs
-+++ /dev/null
-@@ -1,35 +0,0 @@
--//! Mask reductions implementation for `x86` and `x86_64` targets with `SSE`.
--#![allow(unused)]
--
--/// `x86`/`x86_64` 128-bit `m32x4` `SSE` implementation
--macro_rules! x86_m32x4_sse_impl {
--    ($id:ident) => {
--        impl All for $id {
--            #[inline]
--            #[target_feature(enable = "sse")]
--            unsafe fn all(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm_movemask_ps;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm_movemask_ps;
--                // _mm_movemask_ps(a) creates a 4bit mask containing the
--                // most significant bit of each lane of `a`. If all
--                // bits are set, then all 4 lanes of the mask are
--                // true.
--                _mm_movemask_ps(crate::mem::transmute(self)) == 0b_1111_i32
--            }
--        }
--        impl Any for $id {
--            #[inline]
--            #[target_feature(enable = "sse")]
--            unsafe fn any(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm_movemask_ps;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm_movemask_ps;
--
--                _mm_movemask_ps(crate::mem::transmute(self)) != 0
--            }
--        }
--    };
--}
-diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse2.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse2.rs
-deleted file mode 100644
-index bbb52fa..0000000
---- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse2.rs
-+++ /dev/null
-@@ -1,68 +0,0 @@
--//! Mask reductions implementation for `x86` and `x86_64` targets with `SSE2`.
--#![allow(unused)]
--
--/// `x86`/`x86_64` 128-bit m64x2 `SSE2` implementation
--macro_rules! x86_m64x2_sse2_impl {
--    ($id:ident) => {
--        impl All for $id {
--            #[inline]
--            #[target_feature(enable = "sse")]
--            unsafe fn all(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm_movemask_pd;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm_movemask_pd;
--                // _mm_movemask_pd(a) creates a 2bit mask containing the
--                // most significant bit of each lane of `a`. If all
--                // bits are set, then all 2 lanes of the mask are
--                // true.
--                _mm_movemask_pd(crate::mem::transmute(self)) == 0b_11_i32
--            }
--        }
--        impl Any for $id {
--            #[inline]
--            #[target_feature(enable = "sse")]
--            unsafe fn any(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm_movemask_pd;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm_movemask_pd;
--
--                _mm_movemask_pd(crate::mem::transmute(self)) != 0
--            }
--        }
--    };
--}
--
--/// `x86`/`x86_64` 128-bit m8x16 `SSE2` implementation
--macro_rules! x86_m8x16_sse2_impl {
--    ($id:ident) => {
--        impl All for $id {
--            #[inline]
--            #[target_feature(enable = "sse2")]
--            unsafe fn all(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm_movemask_epi8;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm_movemask_epi8;
--                // _mm_movemask_epi8(a) creates a 16bit mask containing the
--                // most significant bit of each byte of `a`. If all
--                // bits are set, then all 16 lanes of the mask are
--                // true.
--                _mm_movemask_epi8(crate::mem::transmute(self)) == i32::from(u16::max_value())
--            }
--        }
--        impl Any for $id {
--            #[inline]
--            #[target_feature(enable = "sse2")]
--            unsafe fn any(self) -> bool {
--                #[cfg(target_arch = "x86")]
--                use crate::arch::x86::_mm_movemask_epi8;
--                #[cfg(target_arch = "x86_64")]
--                use crate::arch::x86_64::_mm_movemask_epi8;
--
--                _mm_movemask_epi8(crate::mem::transmute(self)) != 0
--            }
--        }
--    };
--}
 diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86.rs
 deleted file mode 100644
-index 4bf5098..0000000
 --- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86.rs
 +++ /dev/null
 @@ -1,216 +0,0 @@
@@ -20037,91 +20928,261 @@ index 4bf5098..0000000
 -        fallback_impl!($id);
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask.rs
+diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx.rs
 deleted file mode 100644
-index a78bcc5..0000000
---- a/third_party/rust/packed_simd/src/codegen/reductions/mask.rs
+--- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx.rs
 +++ /dev/null
-@@ -1,69 +0,0 @@
--//! Code generation workaround for `all()` mask horizontal reduction.
--//!
--//! Works around [LLVM bug 36702].
--//!
--//! [LLVM bug 36702]: https://bugs.llvm.org/show_bug.cgi?id=36702
--#![allow(unused_macros)]
+@@ -1,95 +0,0 @@
+-//! Mask reductions implementation for `x86` and `x86_64` targets with `AVX`
 -
--use crate::*;
--
--pub(crate) trait All: crate::marker::Sized {
--    unsafe fn all(self) -> bool;
+-/// `x86`/`x86_64` 256-bit `AVX` implementation
+-/// FIXME: it might be faster here to do two `_mm_movmask_epi8`
+-#[cfg(target_feature = "avx")]
+-macro_rules! x86_m8x32_avx_impl {
+-    ($id:ident) => {
+-        impl All for $id {
+-            #[inline]
+-            #[target_feature(enable = "avx")]
+-            unsafe fn all(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm256_testc_si256;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm256_testc_si256;
+-                _mm256_testc_si256(crate::mem::transmute(self), crate::mem::transmute($id::splat(true))) != 0
+-            }
+-        }
+-        impl Any for $id {
+-            #[inline]
+-            #[target_feature(enable = "avx")]
+-            unsafe fn any(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm256_testz_si256;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm256_testz_si256;
+-                _mm256_testz_si256(crate::mem::transmute(self), crate::mem::transmute(self)) == 0
+-            }
+-        }
+-    };
 -}
 -
--pub(crate) trait Any: crate::marker::Sized {
--    unsafe fn any(self) -> bool;
+-/// `x86`/`x86_64` 256-bit m32x8 `AVX` implementation
+-macro_rules! x86_m32x8_avx_impl {
+-    ($id:ident) => {
+-        impl All for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse")]
+-            unsafe fn all(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm256_movemask_ps;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm256_movemask_ps;
+-                // _mm256_movemask_ps(a) creates a 8bit mask containing the
+-                // most significant bit of each lane of `a`. If all bits are
+-                // set, then all 8 lanes of the mask are true.
+-                _mm256_movemask_ps(crate::mem::transmute(self)) == 0b_1111_1111_i32
+-            }
+-        }
+-        impl Any for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse")]
+-            unsafe fn any(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm256_movemask_ps;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm256_movemask_ps;
+-
+-                _mm256_movemask_ps(crate::mem::transmute(self)) != 0
+-            }
+-        }
+-    };
 -}
 -
--#[macro_use]
--mod fallback_impl;
+-/// `x86`/`x86_64` 256-bit m64x4 `AVX` implementation
+-macro_rules! x86_m64x4_avx_impl {
+-    ($id:ident) => {
+-        impl All for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse")]
+-            unsafe fn all(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm256_movemask_pd;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm256_movemask_pd;
+-                // _mm256_movemask_pd(a) creates a 4bit mask containing the
+-                // most significant bit of each lane of `a`. If all bits are
+-                // set, then all 4 lanes of the mask are true.
+-                _mm256_movemask_pd(crate::mem::transmute(self)) == 0b_1111_i32
+-            }
+-        }
+-        impl Any for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse")]
+-            unsafe fn any(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm256_movemask_pd;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm256_movemask_pd;
 -
--cfg_if! {
--    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
--        #[macro_use]
--        mod x86;
--    } else if #[cfg(all(target_arch = "arm", target_feature = "v7",
--                        target_feature = "neon",
--                        any(feature = "core_arch", libcore_neon)))] {
--        #[macro_use]
--        mod arm;
--    } else if #[cfg(all(target_arch = "aarch64", target_feature = "neon"))] {
--        #[macro_use]
--        mod aarch64;
--    } else {
--        #[macro_use]
--        mod fallback;
--    }
+-                _mm256_movemask_pd(crate::mem::transmute(self)) != 0
+-            }
+-        }
+-    };
 -}
--
--impl_mask_reductions!(m8x2);
--impl_mask_reductions!(m8x4);
--impl_mask_reductions!(m8x8);
--impl_mask_reductions!(m8x16);
--impl_mask_reductions!(m8x32);
--impl_mask_reductions!(m8x64);
--
--impl_mask_reductions!(m16x2);
--impl_mask_reductions!(m16x4);
--impl_mask_reductions!(m16x8);
--impl_mask_reductions!(m16x16);
--impl_mask_reductions!(m16x32);
--
--impl_mask_reductions!(m32x2);
--impl_mask_reductions!(m32x4);
--impl_mask_reductions!(m32x8);
--impl_mask_reductions!(m32x16);
--
--// FIXME: 64-bit single element vector
--// impl_mask_reductions!(m64x1);
--impl_mask_reductions!(m64x2);
--impl_mask_reductions!(m64x4);
--impl_mask_reductions!(m64x8);
--
--impl_mask_reductions!(m128x1);
--impl_mask_reductions!(m128x2);
--impl_mask_reductions!(m128x4);
--
--impl_mask_reductions!(msizex2);
--impl_mask_reductions!(msizex4);
--impl_mask_reductions!(msizex8);
-diff --git a/third_party/rust/packed_simd/src/codegen/reductions.rs b/third_party/rust/packed_simd/src/codegen/reductions.rs
+diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx2.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx2.rs
 deleted file mode 100644
-index 302ca6d..0000000
---- a/third_party/rust/packed_simd/src/codegen/reductions.rs
+--- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/avx2.rs
 +++ /dev/null
-@@ -1 +0,0 @@
--pub(crate) mod mask;
+@@ -1,35 +0,0 @@
+-//! Mask reductions implementation for `x86` and `x86_64` targets with `AVX2`.
+-#![allow(unused)]
+-
+-/// x86/x86_64 256-bit m8x32 AVX2 implementation
+-macro_rules! x86_m8x32_avx2_impl {
+-    ($id:ident) => {
+-        impl All for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse2")]
+-            unsafe fn all(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm256_movemask_epi8;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm256_movemask_epi8;
+-                // _mm256_movemask_epi8(a) creates a 32bit mask containing the
+-                // most significant bit of each byte of `a`. If all
+-                // bits are set, then all 32 lanes of the mask are
+-                // true.
+-                _mm256_movemask_epi8(crate::mem::transmute(self)) == -1_i32
+-            }
+-        }
+-        impl Any for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse2")]
+-            unsafe fn any(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm256_movemask_epi8;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm256_movemask_epi8;
+-
+-                _mm256_movemask_epi8(crate::mem::transmute(self)) != 0
+-            }
+-        }
+-    };
+-}
+diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse.rs
++++ /dev/null
+@@ -1,35 +0,0 @@
+-//! Mask reductions implementation for `x86` and `x86_64` targets with `SSE`.
+-#![allow(unused)]
+-
+-/// `x86`/`x86_64` 128-bit `m32x4` `SSE` implementation
+-macro_rules! x86_m32x4_sse_impl {
+-    ($id:ident) => {
+-        impl All for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse")]
+-            unsafe fn all(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm_movemask_ps;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm_movemask_ps;
+-                // _mm_movemask_ps(a) creates a 4bit mask containing the
+-                // most significant bit of each lane of `a`. If all
+-                // bits are set, then all 4 lanes of the mask are
+-                // true.
+-                _mm_movemask_ps(crate::mem::transmute(self)) == 0b_1111_i32
+-            }
+-        }
+-        impl Any for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse")]
+-            unsafe fn any(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm_movemask_ps;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm_movemask_ps;
+-
+-                _mm_movemask_ps(crate::mem::transmute(self)) != 0
+-            }
+-        }
+-    };
+-}
+diff --git a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse2.rs b/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse2.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/codegen/reductions/mask/x86/sse2.rs
++++ /dev/null
+@@ -1,68 +0,0 @@
+-//! Mask reductions implementation for `x86` and `x86_64` targets with `SSE2`.
+-#![allow(unused)]
+-
+-/// `x86`/`x86_64` 128-bit m64x2 `SSE2` implementation
+-macro_rules! x86_m64x2_sse2_impl {
+-    ($id:ident) => {
+-        impl All for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse")]
+-            unsafe fn all(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm_movemask_pd;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm_movemask_pd;
+-                // _mm_movemask_pd(a) creates a 2bit mask containing the
+-                // most significant bit of each lane of `a`. If all
+-                // bits are set, then all 2 lanes of the mask are
+-                // true.
+-                _mm_movemask_pd(crate::mem::transmute(self)) == 0b_11_i32
+-            }
+-        }
+-        impl Any for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse")]
+-            unsafe fn any(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm_movemask_pd;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm_movemask_pd;
+-
+-                _mm_movemask_pd(crate::mem::transmute(self)) != 0
+-            }
+-        }
+-    };
+-}
+-
+-/// `x86`/`x86_64` 128-bit m8x16 `SSE2` implementation
+-macro_rules! x86_m8x16_sse2_impl {
+-    ($id:ident) => {
+-        impl All for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse2")]
+-            unsafe fn all(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm_movemask_epi8;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm_movemask_epi8;
+-                // _mm_movemask_epi8(a) creates a 16bit mask containing the
+-                // most significant bit of each byte of `a`. If all
+-                // bits are set, then all 16 lanes of the mask are
+-                // true.
+-                _mm_movemask_epi8(crate::mem::transmute(self)) == i32::from(u16::max_value())
+-            }
+-        }
+-        impl Any for $id {
+-            #[inline]
+-            #[target_feature(enable = "sse2")]
+-            unsafe fn any(self) -> bool {
+-                #[cfg(target_arch = "x86")]
+-                use crate::arch::x86::_mm_movemask_epi8;
+-                #[cfg(target_arch = "x86_64")]
+-                use crate::arch::x86_64::_mm_movemask_epi8;
+-
+-                _mm_movemask_epi8(crate::mem::transmute(self)) != 0
+-            }
+-        }
+-    };
+-}
 diff --git a/third_party/rust/packed_simd/src/codegen/shuffle.rs b/third_party/rust/packed_simd/src/codegen/shuffle.rs
 deleted file mode 100644
-index d3acd48..0000000
 --- a/third_party/rust/packed_simd/src/codegen/shuffle.rs
 +++ /dev/null
 @@ -1,150 +0,0 @@
@@ -20277,7 +21338,6 @@ index d3acd48..0000000
 -impl_shuffle! { [u32; 4], m128, crate::codegen::m128x4 }
 diff --git a/third_party/rust/packed_simd/src/codegen/shuffle1_dyn.rs b/third_party/rust/packed_simd/src/codegen/shuffle1_dyn.rs
 deleted file mode 100644
-index 19d457a..0000000
 --- a/third_party/rust/packed_simd/src/codegen/shuffle1_dyn.rs
 +++ /dev/null
 @@ -1,408 +0,0 @@
@@ -20691,7 +21751,6 @@ index 19d457a..0000000
 -impl_shuffle1_dyn_ptr!(mptrx8, usizex8);
 diff --git a/third_party/rust/packed_simd/src/codegen/swap_bytes.rs b/third_party/rust/packed_simd/src/codegen/swap_bytes.rs
 deleted file mode 100644
-index 9cf34a3..0000000
 --- a/third_party/rust/packed_simd/src/codegen/swap_bytes.rs
 +++ /dev/null
 @@ -1,149 +0,0 @@
@@ -20846,7 +21905,6 @@ index 9cf34a3..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/codegen/v128.rs b/third_party/rust/packed_simd/src/codegen/v128.rs
 deleted file mode 100644
-index 9506424..0000000
 --- a/third_party/rust/packed_simd/src/codegen/v128.rs
 +++ /dev/null
 @@ -1,46 +0,0 @@
@@ -20898,7 +21956,6 @@ index 9506424..0000000
 -impl_simd_array!([m128; 1]: m128x1 | i128);
 diff --git a/third_party/rust/packed_simd/src/codegen/v16.rs b/third_party/rust/packed_simd/src/codegen/v16.rs
 deleted file mode 100644
-index 4d55a6d..0000000
 --- a/third_party/rust/packed_simd/src/codegen/v16.rs
 +++ /dev/null
 @@ -1,7 +0,0 @@
@@ -20911,7 +21968,6 @@ index 4d55a6d..0000000
 -impl_simd_array!([m8; 2]: m8x2 | i8, i8);
 diff --git a/third_party/rust/packed_simd/src/codegen/v256.rs b/third_party/rust/packed_simd/src/codegen/v256.rs
 deleted file mode 100644
-index 5ca4759..0000000
 --- a/third_party/rust/packed_simd/src/codegen/v256.rs
 +++ /dev/null
 @@ -1,78 +0,0 @@
@@ -20995,7 +22051,6 @@ index 5ca4759..0000000
 -impl_simd_array!([m128; 2]: m128x2 | i128, i128);
 diff --git a/third_party/rust/packed_simd/src/codegen/v32.rs b/third_party/rust/packed_simd/src/codegen/v32.rs
 deleted file mode 100644
-index ae1dabd..0000000
 --- a/third_party/rust/packed_simd/src/codegen/v32.rs
 +++ /dev/null
 @@ -1,11 +0,0 @@
@@ -21012,7 +22067,6 @@ index ae1dabd..0000000
 -impl_simd_array!([m16; 2]: m16x2 | i16, i16);
 diff --git a/third_party/rust/packed_simd/src/codegen/v512.rs b/third_party/rust/packed_simd/src/codegen/v512.rs
 deleted file mode 100644
-index bf95110..0000000
 --- a/third_party/rust/packed_simd/src/codegen/v512.rs
 +++ /dev/null
 @@ -1,145 +0,0 @@
@@ -21163,7 +22217,6 @@ index bf95110..0000000
 -impl_simd_array!([m128; 4]: m128x4 | i128, i128, i128, i128);
 diff --git a/third_party/rust/packed_simd/src/codegen/v64.rs b/third_party/rust/packed_simd/src/codegen/v64.rs
 deleted file mode 100644
-index 3cfb67c..0000000
 --- a/third_party/rust/packed_simd/src/codegen/v64.rs
 +++ /dev/null
 @@ -1,21 +0,0 @@
@@ -21190,7 +22243,6 @@ index 3cfb67c..0000000
 -impl_simd_array!([m64; 1]: m64x1 | i64);
 diff --git a/third_party/rust/packed_simd/src/codegen/vPtr.rs b/third_party/rust/packed_simd/src/codegen/vPtr.rs
 deleted file mode 100644
-index abd3aa8..0000000
 --- a/third_party/rust/packed_simd/src/codegen/vPtr.rs
 +++ /dev/null
 @@ -1,35 +0,0 @@
@@ -21231,7 +22283,6 @@ index abd3aa8..0000000
 -impl_simd_ptr!([*mut T; 8]: mptrx8 | T | T, T, T, T, T, T, T, T);
 diff --git a/third_party/rust/packed_simd/src/codegen/vSize.rs b/third_party/rust/packed_simd/src/codegen/vSize.rs
 deleted file mode 100644
-index d5db039..0000000
 --- a/third_party/rust/packed_simd/src/codegen/vSize.rs
 +++ /dev/null
 @@ -1,16 +0,0 @@
@@ -21251,77 +22302,8 @@ index d5db039..0000000
 -impl_simd_array!([isize; 8]: isizex8 | isize_, isize_, isize_, isize_, isize_, isize_, isize_, isize_);
 -impl_simd_array!([usize; 8]: usizex8 | usize_, usize_, usize_, usize_, usize_, usize_, usize_, usize_);
 -impl_simd_array!([msize; 8]: msizex8 | isize_, isize_, isize_, isize_, isize_, isize_, isize_, isize_);
-diff --git a/third_party/rust/packed_simd/src/codegen.rs b/third_party/rust/packed_simd/src/codegen.rs
-deleted file mode 100644
-index 8a9e971..0000000
---- a/third_party/rust/packed_simd/src/codegen.rs
-+++ /dev/null
-@@ -1,62 +0,0 @@
--//! Code-generation utilities
--
--pub(crate) mod bit_manip;
--pub(crate) mod llvm;
--pub(crate) mod math;
--pub(crate) mod reductions;
--pub(crate) mod shuffle;
--pub(crate) mod shuffle1_dyn;
--pub(crate) mod swap_bytes;
--
--macro_rules! impl_simd_array {
--    ([$elem_ty:ident; $elem_count:expr]:
--     $tuple_id:ident | $($elem_tys:ident),*) => {
--        #[derive(Copy, Clone)]
--        #[repr(simd)]
--        pub struct $tuple_id($(pub(crate) $elem_tys),*);
--        //^^^^^^^ leaked through SimdArray
--
--        impl crate::sealed::Seal for [$elem_ty; $elem_count] {}
--
--        impl crate::sealed::SimdArray for [$elem_ty; $elem_count] {
--            type Tuple = $tuple_id;
--            type T = $elem_ty;
--            const N: usize = $elem_count;
--            type NT = [u32; $elem_count];
--        }
--
--        impl crate::sealed::Seal for $tuple_id {}
--        impl crate::sealed::Simd for $tuple_id {
--            type Element = $elem_ty;
--            const LANES: usize = $elem_count;
--            type LanesType = [u32; $elem_count];
--        }
--
--    }
--}
--
--pub(crate) mod pointer_sized_int;
--
--pub(crate) mod v16;
--pub(crate) use self::v16::*;
--
--pub(crate) mod v32;
--pub(crate) use self::v32::*;
--
--pub(crate) mod v64;
--pub(crate) use self::v64::*;
--
--pub(crate) mod v128;
--pub(crate) use self::v128::*;
--
--pub(crate) mod v256;
--pub(crate) use self::v256::*;
--
--pub(crate) mod v512;
--pub(crate) use self::v512::*;
--
--pub(crate) mod vSize;
--pub(crate) use self::vSize::*;
--
--pub(crate) mod vPtr;
--pub(crate) use self::vPtr::*;
 diff --git a/third_party/rust/packed_simd/src/lib.rs b/third_party/rust/packed_simd/src/lib.rs
 deleted file mode 100644
-index 867cc10..0000000
 --- a/third_party/rust/packed_simd/src/lib.rs
 +++ /dev/null
 @@ -1,348 +0,0 @@
@@ -21675,7 +22657,6 @@ index 867cc10..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/masks.rs b/third_party/rust/packed_simd/src/masks.rs
 deleted file mode 100644
-index 04534ea..0000000
 --- a/third_party/rust/packed_simd/src/masks.rs
 +++ /dev/null
 @@ -1,126 +0,0 @@
@@ -21807,7 +22788,6 @@ index 04534ea..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/sealed.rs b/third_party/rust/packed_simd/src/sealed.rs
 deleted file mode 100644
-index 0ec2030..0000000
 --- a/third_party/rust/packed_simd/src/sealed.rs
 +++ /dev/null
 @@ -1,42 +0,0 @@
@@ -21853,9 +22833,21 @@ index 0ec2030..0000000
 -pub trait Mask: Seal {
 -    fn test(&self) -> bool;
 -}
+diff --git a/third_party/rust/packed_simd/src/testing.rs b/third_party/rust/packed_simd/src/testing.rs
+deleted file mode 100644
+--- a/third_party/rust/packed_simd/src/testing.rs
++++ /dev/null
+@@ -1,8 +0,0 @@
+-//! Testing macros and other utilities.
+-
+-#[macro_use]
+-mod macros;
+-
+-#[cfg(test)]
+-#[macro_use]
+-pub(crate) mod utils;
 diff --git a/third_party/rust/packed_simd/src/testing/macros.rs b/third_party/rust/packed_simd/src/testing/macros.rs
 deleted file mode 100644
-index 7bc4268..0000000
 --- a/third_party/rust/packed_simd/src/testing/macros.rs
 +++ /dev/null
 @@ -1,44 +0,0 @@
@@ -21905,7 +22897,6 @@ index 7bc4268..0000000
 -}
 diff --git a/third_party/rust/packed_simd/src/testing/utils.rs b/third_party/rust/packed_simd/src/testing/utils.rs
 deleted file mode 100644
-index 7d8f395..0000000
 --- a/third_party/rust/packed_simd/src/testing/utils.rs
 +++ /dev/null
 @@ -1,130 +0,0 @@
@@ -22039,23 +23030,8 @@ index 7d8f395..0000000
 -        }
 -    };
 -}
-diff --git a/third_party/rust/packed_simd/src/testing.rs b/third_party/rust/packed_simd/src/testing.rs
-deleted file mode 100644
-index 6320b28..0000000
---- a/third_party/rust/packed_simd/src/testing.rs
-+++ /dev/null
-@@ -1,8 +0,0 @@
--//! Testing macros and other utilities.
--
--#[macro_use]
--mod macros;
--
--#[cfg(test)]
--#[macro_use]
--pub(crate) mod utils;
 diff --git a/third_party/rust/packed_simd/src/v128.rs b/third_party/rust/packed_simd/src/v128.rs
 deleted file mode 100644
-index 7949f66..0000000
 --- a/third_party/rust/packed_simd/src/v128.rs
 +++ /dev/null
 @@ -1,80 +0,0 @@
@@ -22141,7 +23117,6 @@ index 7949f66..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/v16.rs b/third_party/rust/packed_simd/src/v16.rs
 deleted file mode 100644
-index 4ca5afb..0000000
 --- a/third_party/rust/packed_simd/src/v16.rs
 +++ /dev/null
 @@ -1,16 +0,0 @@
@@ -22163,7 +23138,6 @@ index 4ca5afb..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/v256.rs b/third_party/rust/packed_simd/src/v256.rs
 deleted file mode 100644
-index f0c3bc2..0000000
 --- a/third_party/rust/packed_simd/src/v256.rs
 +++ /dev/null
 @@ -1,86 +0,0 @@
@@ -22255,7 +23229,6 @@ index f0c3bc2..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/v32.rs b/third_party/rust/packed_simd/src/v32.rs
 deleted file mode 100644
-index 75a1838..0000000
 --- a/third_party/rust/packed_simd/src/v32.rs
 +++ /dev/null
 @@ -1,29 +0,0 @@
@@ -22290,7 +23263,6 @@ index 75a1838..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/v512.rs b/third_party/rust/packed_simd/src/v512.rs
 deleted file mode 100644
-index 4c8c713..0000000
 --- a/third_party/rust/packed_simd/src/v512.rs
 +++ /dev/null
 @@ -1,99 +0,0 @@
@@ -22395,7 +23367,6 @@ index 4c8c713..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/v64.rs b/third_party/rust/packed_simd/src/v64.rs
 deleted file mode 100644
-index bf6b9de..0000000
 --- a/third_party/rust/packed_simd/src/v64.rs
 +++ /dev/null
 @@ -1,66 +0,0 @@
@@ -22467,7 +23438,6 @@ index bf6b9de..0000000
 -*/
 diff --git a/third_party/rust/packed_simd/src/vPtr.rs b/third_party/rust/packed_simd/src/vPtr.rs
 deleted file mode 100644
-index e34cb17..0000000
 --- a/third_party/rust/packed_simd/src/vPtr.rs
 +++ /dev/null
 @@ -1,34 +0,0 @@
@@ -22507,7 +23477,6 @@ index e34cb17..0000000
 -);
 diff --git a/third_party/rust/packed_simd/src/vSize.rs b/third_party/rust/packed_simd/src/vSize.rs
 deleted file mode 100644
-index b5d8910..0000000
 --- a/third_party/rust/packed_simd/src/vSize.rs
 +++ /dev/null
 @@ -1,53 +0,0 @@
@@ -22566,7 +23535,6 @@ index b5d8910..0000000
 -);
 diff --git a/third_party/rust/packed_simd/tests/endianness.rs b/third_party/rust/packed_simd/tests/endianness.rs
 deleted file mode 100644
-index 17a7796..0000000
 --- a/third_party/rust/packed_simd/tests/endianness.rs
 +++ /dev/null
 @@ -1,268 +0,0 @@
@@ -22840,15 +23808,13 @@ index 17a7796..0000000
 -}
 diff --git a/third_party/rust/version_check/.cargo-checksum.json b/third_party/rust/version_check/.cargo-checksum.json
 new file mode 100644
-index 0000000..dd79d12
 --- /dev/null
 +++ b/third_party/rust/version_check/.cargo-checksum.json
-@@ -0,0 +1 @@
+@@ -0,0 +1,1 @@
 +{"files":{"Cargo.toml":"f25d88044914cb3466df43bc39a199e1589dda1aad3226c9c7e7ac4d2f8751d0","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"b7e650f3fce5c53249d1cdc608b54df156a97edd636cf9d23498d0cfe7aec63e","README.md":"ac2a0a360812436bd5798f5fe2affe7d6ed9eb7f15d6e4d73931e95b437560f2","src/channel.rs":"d2443d503d4cc469a171a51a26eca3ec0d2a58b5f7375a84542c36f1421766a8","src/date.rs":"09580a0a2008fad2ccbc43fb42a88f42221b98b01692702022a296dc9c86bf37","src/lib.rs":"760f0d29567ecaa61287088cf23cf74b3c0efbbcd3077cea5fb7c88359e96c7e","src/version.rs":"dba18a25983ec6e37b952f4cdc5219c9e5abba2c3a76cef87465e1fba6f8ac89"},"package":"49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"}
 \ No newline at end of file
 diff --git a/third_party/rust/version_check/Cargo.toml b/third_party/rust/version_check/Cargo.toml
 new file mode 100644
-index 0000000..39fedbd
 --- /dev/null
 +++ b/third_party/rust/version_check/Cargo.toml
 @@ -0,0 +1,24 @@
@@ -22878,7 +23844,6 @@ index 0000000..39fedbd
 +[dependencies]
 diff --git a/third_party/rust/version_check/LICENSE-APACHE b/third_party/rust/version_check/LICENSE-APACHE
 new file mode 100644
-index 0000000..16fe87b
 --- /dev/null
 +++ b/third_party/rust/version_check/LICENSE-APACHE
 @@ -0,0 +1,201 @@
@@ -23085,7 +24050,6 @@ index 0000000..16fe87b
 +limitations under the License.
 diff --git a/third_party/rust/version_check/LICENSE-MIT b/third_party/rust/version_check/LICENSE-MIT
 new file mode 100644
-index 0000000..dfc0e73
 --- /dev/null
 +++ b/third_party/rust/version_check/LICENSE-MIT
 @@ -0,0 +1,19 @@
@@ -23110,7 +24074,6 @@ index 0000000..dfc0e73
 +CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 diff --git a/third_party/rust/version_check/README.md b/third_party/rust/version_check/README.md
 new file mode 100644
-index 0000000..8637d2a
 --- /dev/null
 +++ b/third_party/rust/version_check/README.md
 @@ -0,0 +1,80 @@
@@ -23196,7 +24159,6 @@ index 0000000..8637d2a
 + * MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 diff --git a/third_party/rust/version_check/src/channel.rs b/third_party/rust/version_check/src/channel.rs
 new file mode 100644
-index 0000000..f84c508
 --- /dev/null
 +++ b/third_party/rust/version_check/src/channel.rs
 @@ -0,0 +1,193 @@
@@ -23395,7 +24357,6 @@ index 0000000..f84c508
 +}
 diff --git a/third_party/rust/version_check/src/date.rs b/third_party/rust/version_check/src/date.rs
 new file mode 100644
-index 0000000..de0b2d0
 --- /dev/null
 +++ b/third_party/rust/version_check/src/date.rs
 @@ -0,0 +1,203 @@
@@ -23604,7 +24565,6 @@ index 0000000..de0b2d0
 +}
 diff --git a/third_party/rust/version_check/src/lib.rs b/third_party/rust/version_check/src/lib.rs
 new file mode 100644
-index 0000000..6c16074
 --- /dev/null
 +++ b/third_party/rust/version_check/src/lib.rs
 @@ -0,0 +1,493 @@
@@ -24103,7 +25063,6 @@ index 0000000..6c16074
 +}
 diff --git a/third_party/rust/version_check/src/version.rs b/third_party/rust/version_check/src/version.rs
 new file mode 100644
-index 0000000..2bc18aa
 --- /dev/null
 +++ b/third_party/rust/version_check/src/version.rs
 @@ -0,0 +1,316 @@

--- a/seamonkey/6010-update-encoding_rs-mozbg1882209-133a1.patch
+++ b/seamonkey/6010-update-encoding_rs-mozbg1882209-133a1.patch
@@ -1,0 +1,1387 @@
+# HG changeset patch
+# User Henri Sivonen <hsivonen@hsivonen.fi>
+# Date 1729852895 0
+# Node ID 8ec6ccd6447aa2f8ed175c16b272ac7dd46e946b
+# Parent  a0a53a3fe6b0e4720407a8f7fea85e8cfcbbd093
+Bug 1866191 - Implement GB18030-2022 changes to the Encoding Standard. r=supply-chain-reviewers,emk
+
+Differential Revision: https://phabricator.services.mozilla.com/D222928
+
+diff --git a/Cargo.lock b/Cargo.lock
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -614,19 +614,19 @@ version = "0.1.0"
+ dependencies = [
+  "encoding_rs",
+  "nserror",
+  "nsstring",
+ ]
+ 
+ [[package]]
+ name = "encoding_rs"
+-version = "0.8.34"
++version = "0.8.35"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
++checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+ dependencies = [
+  "any_all_workaround",
+  "cfg-if 1.0.0",
+ ]
+ 
+ [[package]]
+ name = "env_logger"
+ version = "0.5.13"
+diff --git a/third_party/rust/encoding_rs/.cargo-checksum.json b/third_party/rust/encoding_rs/.cargo-checksum.json
+--- a/third_party/rust/encoding_rs/.cargo-checksum.json
++++ b/third_party/rust/encoding_rs/.cargo-checksum.json
+@@ -1,1 +1,1 @@
+-{"files":{"CONTRIBUTING.md":"ca1901f3e8532fb4cec894fd3664f0eaa898c0c4b961d1b992d1ed54eacf362a","COPYRIGHT":"11789f45bb180841cd362a5eee6789c68ddb573a11105e30768c308a6add0190","Cargo.toml":"22a4d210c92dae9f32c6944ef340ee8fdd027f99c081577e8907123e2a93383e","Ideas.md":"b7452893f500163868d8de52c09addaf91e1632454ed02e892c467ed7ec39dbd","LICENSE-APACHE":"cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","LICENSE-MIT":"3fa4ca83dcc9237839b1bdeb2e6d16bdfb5ec0c5ce42b24694d8bbf0dcbef72c","LICENSE-WHATWG":"838118388fe5c2e7f1dbbaeed13e1c7f3ebf88be91319c7c1d77c18e987d1a50","README.md":"1d08aefcb92afa81b18154049c9abbcad4540a23f7172e9f9bbed5af33f1a087","ci/miri.sh":"43cb8d82f49e3bfe2d2274b6ccd6f0714a4188ccef0cecc040829883cfdbee25","doc/Big5.txt":"f73a2edc5cb6c2d140ba6e07f4542e1c4a234950378acde1df93480f0ca0be0b","doc/EUC-JP.txt":"ee2818b907d0137f40a9ab9fd525fc700a44dbdddb6cf0c157a656566bae4bf1","doc/EUC-KR.txt":"71d9e2ccf3b124e8bdfb433c8cf2773fd878077038d0cec3c7237a50f4a78a30","doc/GBK.txt":"c1b522b5a799884e5001da661f42c5a8f4d0acb9ef1d74b206f22b5f65365606","doc/IBM866.txt":"a5a433e804d0f83af785015179fbc1d9b0eaf1f7960efcd04093e136b51fbd0e","doc/ISO-2022-JP.txt":"af86684f5a8f0e2868d7b2c292860140c3d2e5527530ca091f1b28198e8e2fe6","doc/ISO-8859-10.txt":"6d3949ad7c81ca176895101ed81a1db7df1060d64e262880b94bd31bb344ab4d","doc/ISO-8859-13.txt":"3951dd89cf93f7729148091683cf8511f4529388b7dc8dcd0d62eaed55be93fa","doc/ISO-8859-14.txt":"3d330784a0374fd255a38b47949675cc7168c800530534b0a01cac6edc623adc","doc/ISO-8859-15.txt":"24b1084aab5127a85aab99153f86e24694d0a3615f53b5ce23683f97cf66c47a","doc/ISO-8859-16.txt":"ce0272559b92ba76d7a7e476f6424ae4a5cc72e75b183611b08392e44add4d25","doc/ISO-8859-2.txt":"18ceff88c13d1b5ba455a3919b1e3de489045c4c3d2dd7e8527c125c75d54aad","doc/ISO-8859-3.txt":"21798404c68f4f5db59223362f24999da96968c0628427321fccce7d2849a130","doc/ISO-8859-4.txt":"d27f6520c6c5bfbcc19176b71d081cdb3bccde1622bb3e420d5680e812632d53","doc/ISO-8859-5.txt":"a10ec8d6ea7a78ad15da7275f6cb1a3365118527e28f9af6d0d5830501303f3a","doc/ISO-8859-6.txt":"ccda8a2efc96115336bdd77776637b9712425e44fbcf745353b9057fbef144e7","doc/ISO-8859-7.txt":"17900fa1f27a445958f0a77d7d9056be375a6bd7ee4492aa680c7c1500bab85e","doc/ISO-8859-8-I.txt":"8357555646d54265a9b9ffa3e68b08d132312f1561c60108ff9b8b1167b6ecf2","doc/ISO-8859-8.txt":"72cd6f3afb7b4a9c16a66a362473315770b7755d72c86c870e52fc3eba86c8af","doc/KOI8-R.txt":"839cf19a38da994488004ed7814b1f6151640156a9a2af02bf2efca745fb5966","doc/KOI8-U.txt":"0cc76624ed1f024183e2298b7e019957da2c70c8ca06e0fc4e6f353f50a5054f","doc/Shift_JIS.txt":"34c49141818cb9ddbcf59cc858f78a79be8ad148d563f26415108ae1f148443f","doc/UTF-16BE.txt":"e2e280d8acbaa6d2a6b3569d60e17500a285f2baa0df3363dd85537cd5a1ef8f","doc/UTF-16LE.txt":"70bdc170e3fc5298ba68f10125fb5eeb8b077036cc96bb4416c4de396f6d76c1","doc/UTF-8.txt":"ea7bae742e613010ced002cf4b601a737d2203fad65e115611451bc4428f548a","doc/gb18030.txt":"dc71378a8f07a2d8659f69ee81fb8791fef56ba86f124b429978285237bb4a7b","doc/macintosh.txt":"57491e53866711b4672d9b9ff35380b9dac9e0d8e3d6c20bdd6140603687c023","doc/replacement.txt":"4b6c3bbd7999d9d4108a281594bd02d13607e334a95465afff8c2c08d395f0e4","doc/windows-1250.txt":"61296bb6a21cdab602300d32ecfba434cb82de5ac3bc88d58710d2f125e28d39","doc/windows-1251.txt":"7deea1c61dea1485c8ff02db2c7d578db7a9aab63ab1cfd02ec04b515864689e","doc/windows-1252.txt":"933ef3bdddfce5ee132b9f1a1aa8b47423d2587bbe475b19028d0a6d38e180b6","doc/windows-1253.txt":"1a38748b88e99071a5c7b3d5456ead4caedeabab50d50d658be105bc113714de","doc/windows-1254.txt":"f8372f86c6f8d642563cd6ddc025260553292a39423df1683a98670bd7bf2b47","doc/windows-1255.txt":"4e5852494730054e2da258a74e1b9d780abbcdd8ce22ebc218ca2efe9e90493d","doc/windows-1256.txt":"c0879c5172abedead302a406e8f60d9cd9598694a0ffa4fd288ffe4fef7b8ea1","doc/windows-1257.txt":"c28a0c9f964fcb2b46d21f537c402446501a2800670481d6abf9fd9e9018d523","doc/windows-1258.txt":"5019ae4d61805c79aacbf17c93793342dbb098d65a1837783bc3e2c6d6a23602","doc/windows-874.txt":"4ef0e4501c5feba8b17aee1818602ed44b36ca8475db771ce2fc16d392cabecc","doc/x-mac-cyrillic.txt":"58be154d8a888ca3d484b83b44f749823ef339ab27f14d90ca9a856f5050a8bd","doc/x-user-defined.txt":"f9cd07c4321bf5cfb0be4bdddd251072999b04a6cf7a6f5bc63709a84e2c1ffc","generate-encoding-data.py":"be989dd25c6b946e3e8745fdc8e8a80fcf24b3be99ad0b4b78153ba3f6ab6310","rustfmt.toml":"85c1a3b4382fd89e991cbb81b70fb52780472edc064c963943cdaaa56e0a2030","src/ascii.rs":"588e38b01e666d5e7462617ea7e90a108d608dec9e016f3d273ac0744af2e05d","src/big5.rs":"ec6e2913011a38e9a3e825a1731f139a7ca1d5b264fefae51a3cc1a68a57cef9","src/data.rs":"8a617cc57032092d65850eb27e00de687c80aea3299e839a1f58b42d0b35abf3","src/euc_jp.rs":"32047f5b540188c4cb19c07165f846b9786a09f18e315ed3e9bda1293dae52aa","src/euc_kr.rs":"9b25afc72d9378700eecfac58d55ad1c5946d6cd0ccde2c29c08200ef2de6bb9","src/gb18030.rs":"808587168d73f0c80f8520f0ca9b161866ed2efeb17a05e85fdf3b8efe7ba28a","src/handles.rs":"b08cef1f5785bb6a4822f2e844c6df1b046b737b7a075e4593eaa8c4208e9fe2","src/iso_2022_jp.rs":"9bb485e82574f4b7d4b2364f0ff276acb6a0bc111758420a3b0ec5e04c196652","src/lib.rs":"834f44b670ec48ee82c0e12223d1567313fdd9f88bca5f4b117c82c1828f559f","src/macros.rs":"200997f8870de8bfd8cdc475e92115df42108c0df661e49d3d1cbc32056e1d99","src/mem.rs":"948571137d3b151df8db4fb2c733e74ae595d055cdf0ad83abcab9341d6adabe","src/replacement.rs":"7660b34a53f8c1ca2bdfa0e51e843ec28326950952ad8bc96569feb93ac62308","src/shift_jis.rs":"6951ae67e36b1a12fa3a30734957f444d8b1b4ae0e2bde52060b29bd0f16d9d9","src/simd_funcs.rs":"05c6e77af74bfe73cd39a752067c11425d6b46e5da419910f54bf75a5c02a984","src/single_byte.rs":"3ad87116fb339434a4b58e8f2b15485f2b66b9f7814d708f16194ed08f6d6ccf","src/test_data/big5_in.txt":"4c5a8691f8dc717311889c63894026d2fb62725a86c4208ca274a9cc8d42a503","src/test_data/big5_in_ref.txt":"99d399e17750cf9c7cf30bb253dbfe35b81c4fcbdead93cfa48b1429213473c7","src/test_data/big5_out.txt":"6193ca97c297aa20e09396038d18e938bb7ea331c26f0f2454097296723a0b13","src/test_data/big5_out_ref.txt":"36567691f557df144f6cc520015a87038dfa156f296fcf103b56ae9a718be1fc","src/test_data/euc_kr_in.txt":"c86a7224f3215fa0d04e685622a752fdc72763e8ae076230c7fd62de57ec4074","src/test_data/euc_kr_in_ref.txt":"1f419f4ca47d708b54c73c461545a022ae2e20498fdbf8005a483d752a204883","src/test_data/euc_kr_out.txt":"e7f32e026f70be1e1b58e0047baf7d3d2c520269c4f9b9992e158b4decb0a1a3","src/test_data/euc_kr_out_ref.txt":"c9907857980b20b8e9e3b584482ed6567a2be6185d72237b6322f0404944924e","src/test_data/gb18030_in.txt":"ab7231b2d3e9afacdbd7d7f3b9e5361a7ff9f7e1cfdb4f3bd905b9362b309e53","src/test_data/gb18030_in_ref.txt":"dc5069421adca2043c55f5012b55a76fdff651d22e6e699fd0978f8d5706815c","src/test_data/gb18030_out.txt":"f0208d527f5ca63de7d9a0323be8d5cf12d8a104b2943d92c2701f0c3364dac1","src/test_data/gb18030_out_ref.txt":"6819fe47627e4ea01027003fc514b9f21a1322e732d7f1fb92cc6c5455bc6c07","src/test_data/iso_2022_jp_in.txt":"cd24bbdcb1834e25db54646fbf4c41560a13dc7540f6be3dba4f5d97d44513af","src/test_data/iso_2022_jp_in_ref.txt":"3dc4e6a5e06471942d086b16c9440945e78415f6f3f47e43717e4bc2eac2cdf5","src/test_data/iso_2022_jp_out.txt":"9b6f015329dda6c3f9ee5ce6dbd6fa9c89acc21283e886836c78b8d833480c21","src/test_data/iso_2022_jp_out_ref.txt":"78cb260093a20116ad9a42f43b05d1848c5ab100b6b9a850749809e943884b35","src/test_data/jis0208_in.txt":"6df3030553ffb0a6615bb33dc8ea9dca6d9623a9028e2ffec754ce3c3da824cc","src/test_data/jis0208_in_ref.txt":"3dc4e6a5e06471942d086b16c9440945e78415f6f3f47e43717e4bc2eac2cdf5","src/test_data/jis0208_out.txt":"4ec24477e1675ce750733bdc3c5add1cd27b6bd4ce1f09289564646e9654e857","src/test_data/jis0208_out_ref.txt":"c3e1cef5032b2b1d93a406f31ff940c4e2dfe8859b8b17ca2761fee7a75a0e48","src/test_data/jis0212_in.txt":"c011f0dd72bd7c8cd922df9374ef8d2769a77190514c77f6c62b415852eeb9fe","src/test_data/jis0212_in_ref.txt":"7d9458b3d2f73e7092a7f505c08ce1d233dde18aa679fbcf9889256239cc9e06","src/test_data/shift_jis_in.txt":"02e389ccef0dd2122e63f503899402cb7f797912c2444cc80ab93131116c5524","src/test_data/shift_jis_in_ref.txt":"512f985950ca902e643c88682dba9708b7c38d3c5ec2925168ab00ac94ab19f9","src/test_data/shift_jis_out.txt":"5fbc44da7bf639bf6cfe0fa1fd3eba7102b88f81919c9ea991302712f69426fb","src/test_data/shift_jis_out_ref.txt":"466322c6fed8286c64582731755290c2296508efdd258826e6279686649b481f","src/test_labels_names.rs":"23a2e11b02b3b8d15fb5613a625e3edb2c61e70e3c581abfd638719a4088200d","src/testing.rs":"f59e671e95a98a56f6b573e8c6be4d71e670bf52f7e20eb1605d990aafa1894e","src/utf_16.rs":"c071a147fad38d750c2c247e141b76b929a48007b99f26b2922b9caecdaf2f25","src/utf_8.rs":"7b7d887b347f1aefa03246b028a36a72758a4ce76c28f3b45c19467851aa7839","src/variant.rs":"1fab5363588a1554a7169de8731ea9cded7ac63ea35caabdd1c27a8dde68c27b","src/x_user_defined.rs":"9456ca46168ef86c98399a2536f577ef7be3cdde90c0c51392d8ac48519d3fae"},"package":"b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"}
+\ No newline at end of file
++{"files":{"CONTRIBUTING.md":"ca1901f3e8532fb4cec894fd3664f0eaa898c0c4b961d1b992d1ed54eacf362a","COPYRIGHT":"11789f45bb180841cd362a5eee6789c68ddb573a11105e30768c308a6add0190","Cargo.toml":"d7405d2bcf99cf9729075473c45f677630f4c1947c8ba9757db607f2025a7da2","Ideas.md":"b7452893f500163868d8de52c09addaf91e1632454ed02e892c467ed7ec39dbd","LICENSE-APACHE":"cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","LICENSE-MIT":"3fa4ca83dcc9237839b1bdeb2e6d16bdfb5ec0c5ce42b24694d8bbf0dcbef72c","LICENSE-WHATWG":"838118388fe5c2e7f1dbbaeed13e1c7f3ebf88be91319c7c1d77c18e987d1a50","README.md":"9826137ed4297be3b2019b74a8f6111a796ff507bde41df2f20712539704b9e9","ci/miri.sh":"43cb8d82f49e3bfe2d2274b6ccd6f0714a4188ccef0cecc040829883cfdbee25","doc/Big5.txt":"f73a2edc5cb6c2d140ba6e07f4542e1c4a234950378acde1df93480f0ca0be0b","doc/EUC-JP.txt":"ee2818b907d0137f40a9ab9fd525fc700a44dbdddb6cf0c157a656566bae4bf1","doc/EUC-KR.txt":"71d9e2ccf3b124e8bdfb433c8cf2773fd878077038d0cec3c7237a50f4a78a30","doc/GBK.txt":"8229e59076d8bddb01865cdcf6afda3533238d7c23d97f98820f9e3b2d13505d","doc/IBM866.txt":"a5a433e804d0f83af785015179fbc1d9b0eaf1f7960efcd04093e136b51fbd0e","doc/ISO-2022-JP.txt":"af86684f5a8f0e2868d7b2c292860140c3d2e5527530ca091f1b28198e8e2fe6","doc/ISO-8859-10.txt":"6d3949ad7c81ca176895101ed81a1db7df1060d64e262880b94bd31bb344ab4d","doc/ISO-8859-13.txt":"3951dd89cf93f7729148091683cf8511f4529388b7dc8dcd0d62eaed55be93fa","doc/ISO-8859-14.txt":"3d330784a0374fd255a38b47949675cc7168c800530534b0a01cac6edc623adc","doc/ISO-8859-15.txt":"24b1084aab5127a85aab99153f86e24694d0a3615f53b5ce23683f97cf66c47a","doc/ISO-8859-16.txt":"ce0272559b92ba76d7a7e476f6424ae4a5cc72e75b183611b08392e44add4d25","doc/ISO-8859-2.txt":"18ceff88c13d1b5ba455a3919b1e3de489045c4c3d2dd7e8527c125c75d54aad","doc/ISO-8859-3.txt":"21798404c68f4f5db59223362f24999da96968c0628427321fccce7d2849a130","doc/ISO-8859-4.txt":"d27f6520c6c5bfbcc19176b71d081cdb3bccde1622bb3e420d5680e812632d53","doc/ISO-8859-5.txt":"a10ec8d6ea7a78ad15da7275f6cb1a3365118527e28f9af6d0d5830501303f3a","doc/ISO-8859-6.txt":"ccda8a2efc96115336bdd77776637b9712425e44fbcf745353b9057fbef144e7","doc/ISO-8859-7.txt":"17900fa1f27a445958f0a77d7d9056be375a6bd7ee4492aa680c7c1500bab85e","doc/ISO-8859-8-I.txt":"8357555646d54265a9b9ffa3e68b08d132312f1561c60108ff9b8b1167b6ecf2","doc/ISO-8859-8.txt":"72cd6f3afb7b4a9c16a66a362473315770b7755d72c86c870e52fc3eba86c8af","doc/KOI8-R.txt":"839cf19a38da994488004ed7814b1f6151640156a9a2af02bf2efca745fb5966","doc/KOI8-U.txt":"0cc76624ed1f024183e2298b7e019957da2c70c8ca06e0fc4e6f353f50a5054f","doc/Shift_JIS.txt":"34c49141818cb9ddbcf59cc858f78a79be8ad148d563f26415108ae1f148443f","doc/UTF-16BE.txt":"e2e280d8acbaa6d2a6b3569d60e17500a285f2baa0df3363dd85537cd5a1ef8f","doc/UTF-16LE.txt":"70bdc170e3fc5298ba68f10125fb5eeb8b077036cc96bb4416c4de396f6d76c1","doc/UTF-8.txt":"ea7bae742e613010ced002cf4b601a737d2203fad65e115611451bc4428f548a","doc/gb18030.txt":"67a01665c75505330b0fe5b8d88d5873d8ce555a145c77dca04a467fa2680744","doc/macintosh.txt":"57491e53866711b4672d9b9ff35380b9dac9e0d8e3d6c20bdd6140603687c023","doc/replacement.txt":"4b6c3bbd7999d9d4108a281594bd02d13607e334a95465afff8c2c08d395f0e4","doc/windows-1250.txt":"61296bb6a21cdab602300d32ecfba434cb82de5ac3bc88d58710d2f125e28d39","doc/windows-1251.txt":"7deea1c61dea1485c8ff02db2c7d578db7a9aab63ab1cfd02ec04b515864689e","doc/windows-1252.txt":"933ef3bdddfce5ee132b9f1a1aa8b47423d2587bbe475b19028d0a6d38e180b6","doc/windows-1253.txt":"1a38748b88e99071a5c7b3d5456ead4caedeabab50d50d658be105bc113714de","doc/windows-1254.txt":"f8372f86c6f8d642563cd6ddc025260553292a39423df1683a98670bd7bf2b47","doc/windows-1255.txt":"4e5852494730054e2da258a74e1b9d780abbcdd8ce22ebc218ca2efe9e90493d","doc/windows-1256.txt":"c0879c5172abedead302a406e8f60d9cd9598694a0ffa4fd288ffe4fef7b8ea1","doc/windows-1257.txt":"c28a0c9f964fcb2b46d21f537c402446501a2800670481d6abf9fd9e9018d523","doc/windows-1258.txt":"5019ae4d61805c79aacbf17c93793342dbb098d65a1837783bc3e2c6d6a23602","doc/windows-874.txt":"4ef0e4501c5feba8b17aee1818602ed44b36ca8475db771ce2fc16d392cabecc","doc/x-mac-cyrillic.txt":"58be154d8a888ca3d484b83b44f749823ef339ab27f14d90ca9a856f5050a8bd","doc/x-user-defined.txt":"f9cd07c4321bf5cfb0be4bdddd251072999b04a6cf7a6f5bc63709a84e2c1ffc","generate-encoding-data.py":"6f34a845785f53425accf30759edc566873fcb0c2188648e07b09c898f39dddb","rustfmt.toml":"85c1a3b4382fd89e991cbb81b70fb52780472edc064c963943cdaaa56e0a2030","src/ascii.rs":"588e38b01e666d5e7462617ea7e90a108d608dec9e016f3d273ac0744af2e05d","src/big5.rs":"ec6e2913011a38e9a3e825a1731f139a7ca1d5b264fefae51a3cc1a68a57cef9","src/data.rs":"b93f34025fe5c6a85b4b9f0037bf58961352bf19c83f91b09b35eb8495625eec","src/euc_jp.rs":"32047f5b540188c4cb19c07165f846b9786a09f18e315ed3e9bda1293dae52aa","src/euc_kr.rs":"9b25afc72d9378700eecfac58d55ad1c5946d6cd0ccde2c29c08200ef2de6bb9","src/gb18030.rs":"89cd6ae2247add3f3471a699bc12113a9ae2f6b91a5223abbf15b68a13537dcd","src/gb18030_2022.rs":"3c2e06492c5e00fcd39515e4af4c560d8cee5c31e7a7e388db682bc9ee33ee32","src/handles.rs":"b08cef1f5785bb6a4822f2e844c6df1b046b737b7a075e4593eaa8c4208e9fe2","src/iso_2022_jp.rs":"9bb485e82574f4b7d4b2364f0ff276acb6a0bc111758420a3b0ec5e04c196652","src/lib.rs":"c4d9fa1c43105e2310122f1b9197125032e607fe6f79bc22769b340de76e2430","src/macros.rs":"200997f8870de8bfd8cdc475e92115df42108c0df661e49d3d1cbc32056e1d99","src/mem.rs":"948571137d3b151df8db4fb2c733e74ae595d055cdf0ad83abcab9341d6adabe","src/replacement.rs":"7660b34a53f8c1ca2bdfa0e51e843ec28326950952ad8bc96569feb93ac62308","src/shift_jis.rs":"6951ae67e36b1a12fa3a30734957f444d8b1b4ae0e2bde52060b29bd0f16d9d9","src/simd_funcs.rs":"05c6e77af74bfe73cd39a752067c11425d6b46e5da419910f54bf75a5c02a984","src/single_byte.rs":"3ad87116fb339434a4b58e8f2b15485f2b66b9f7814d708f16194ed08f6d6ccf","src/test_data/big5_in.txt":"a5ae290786610c7facdbb1d06be6815e8bb81d68dfa7380edc7ddb6b8c7e412e","src/test_data/big5_in_ref.txt":"52733d9970fb8987f014fa0eac2792250123cf583b363beb2ce7b3c55e3dc555","src/test_data/big5_out.txt":"57420ca41a669c949738c84cab620020959572d2ee97b4e059405bfe26a79b6d","src/test_data/big5_out_ref.txt":"00e5f67c222dd5cd3bb1739276910b8f0032f454cba7cf7c3eaa255a564188d0","src/test_data/euc_kr_in.txt":"21534ec87e82d785d128f980902d13fab6d9dea15c69a991f409d9b0afd1c852","src/test_data/euc_kr_in_ref.txt":"b3009e6a94967df1f1135c66f005610bebad6666d634aec72d2ad77c3211bda3","src/test_data/euc_kr_out.txt":"20205b0b5be4f579271193b5bfbc549a61a9fd5217c33eecfa61784a3ffe2e9d","src/test_data/euc_kr_out_ref.txt":"b5f566237f8d4ef4d03ad26135ca97dfd7398608a82165bd4853b5134ab22cb5","src/test_data/gb18030_in.txt":"0dd1fbf0360930daafdce7e6761852005a8f92f7910180df19a070b6c3c59dee","src/test_data/gb18030_in_ref.txt":"f3eaea1115857054cf30f8ba18219e72377f2a4afd848ccf223770d75aa4251d","src/test_data/gb18030_out.txt":"7184fe9592609597d55c2733606b4c4b1a18b79b24533e1a16a14ff92e7d2b55","src/test_data/gb18030_out_ref.txt":"23bb850ddc69aaf1bdfeabe05a12d93f614e5560dac879d5f02929ee4a7c06c5","src/test_data/iso_2022_jp_in.txt":"98fb823530a30a76eb0ba7ab6ac796959e8869c1ec143f018a1964581ae813aa","src/test_data/iso_2022_jp_in_ref.txt":"df82166d2e01bb446211d7e46f33b47d93ac1bafeae2ed880ee93c4096d11210","src/test_data/iso_2022_jp_out.txt":"bef8eb4804ed0843b9dffdd1d168738635cc77f8d0929beb2532b686318ddae6","src/test_data/iso_2022_jp_out_ref.txt":"b221b36b2bce49d49b620dc8ba80d77bac74e8660a86a11628e79b67f1d98964","src/test_data/jis0208_in.txt":"3c1a7aaada00d6fff41e60bd7589d7ae94afaf562759b116958b1d84711d17b6","src/test_data/jis0208_in_ref.txt":"df82166d2e01bb446211d7e46f33b47d93ac1bafeae2ed880ee93c4096d11210","src/test_data/jis0208_out.txt":"a6188b67eb00ba980cb83056186c89bcdddc1b0210af9afa78ed1c9b7a098950","src/test_data/jis0208_out_ref.txt":"e75a986fe5e78e64bf8fafd7392ae96ee0cb0a4b2e7ef2fe722b3caacf3e2f70","src/test_data/jis0212_in.txt":"9eda766002646a27310457c661832429beff9089d2703355812c4cac30d800b5","src/test_data/jis0212_in_ref.txt":"fcf74c58d2cbe9b3f3db4fa9eff26e09f5e9644097c78614c03177e938988d03","src/test_data/shift_jis_in.txt":"e65df746be90359e70422868522a7aa3e8ed20e0d4c0cf9995d9de248bf93388","src/test_data/shift_jis_in_ref.txt":"13b15aed64e9e7cb35e6a740b67413f0c285fda944f4814d45a7619ea338fb5e","src/test_data/shift_jis_out.txt":"192d0a4a8ce5d0f904c5cb283dfb974577ee667cf1e71955a6dd6aece2b354ef","src/test_data/shift_jis_out_ref.txt":"cb6d50b0c11bad1d1f1fcc02d779672a8b9a2509cbbafdc6392aceb49c8b4268","src/test_labels_names.rs":"23a2e11b02b3b8d15fb5613a625e3edb2c61e70e3c581abfd638719a4088200d","src/testing.rs":"f59e671e95a98a56f6b573e8c6be4d71e670bf52f7e20eb1605d990aafa1894e","src/utf_16.rs":"c071a147fad38d750c2c247e141b76b929a48007b99f26b2922b9caecdaf2f25","src/utf_8.rs":"7b7d887b347f1aefa03246b028a36a72758a4ce76c28f3b45c19467851aa7839","src/variant.rs":"1fab5363588a1554a7169de8731ea9cded7ac63ea35caabdd1c27a8dde68c27b","src/x_user_defined.rs":"9456ca46168ef86c98399a2536f577ef7be3cdde90c0c51392d8ac48519d3fae"},"package":"75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"}
+\ No newline at end of file
+diff --git a/third_party/rust/encoding_rs/Cargo.toml b/third_party/rust/encoding_rs/Cargo.toml
+--- a/third_party/rust/encoding_rs/Cargo.toml
++++ b/third_party/rust/encoding_rs/Cargo.toml
+@@ -8,18 +8,23 @@
+ # If you are reading this file be aware that the original Cargo.toml
+ # will likely look very different (and much more reasonable).
+ # See Cargo.toml.orig for the original contents.
+ 
+ [package]
+ edition = "2018"
+ rust-version = "1.36"
+ name = "encoding_rs"
+-version = "0.8.34"
++version = "0.8.35"
+ authors = ["Henri Sivonen <hsivonen@hsivonen.fi>"]
++build = false
++autobins = false
++autoexamples = false
++autotests = false
++autobenches = false
+ description = "A Gecko-oriented implementation of the Encoding Standard"
+ homepage = "https://docs.rs/encoding_rs/"
+ documentation = "https://docs.rs/encoding_rs/"
+ readme = "README.md"
+ keywords = [
+     "encoding",
+     "web",
+     "unicode",
+@@ -32,16 +37,20 @@ categories = [
+     "internationalization",
+ ]
+ license = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+ repository = "https://github.com/hsivonen/encoding_rs"
+ 
+ [profile.release]
+ lto = true
+ 
++[lib]
++name = "encoding_rs"
++path = "src/lib.rs"
++
+ [dependencies.any_all_workaround]
+ version = "0.1.0"
+ optional = true
+ 
+ [dependencies.cfg-if]
+ version = "1.0"
+ 
+ [dependencies.serde]
+diff --git a/third_party/rust/encoding_rs/README.md b/third_party/rust/encoding_rs/README.md
+--- a/third_party/rust/encoding_rs/README.md
++++ b/third_party/rust/encoding_rs/README.md
+@@ -103,17 +103,17 @@ For mappings to and from Windows code pa
+ This crate does not support single-byte DOS encodings that aren't required by
+ the Web Platform, but the [`oem_cp`](https://crates.io/crates/oem_cp) crate does.
+ 
+ ## Preparing Text for the Encoders
+ 
+ Normalizing text into Unicode Normalization Form C prior to encoding text into
+ a legacy encoding minimizes unmappable characters. Text can be normalized to
+ Unicode Normalization Form C using the
+-[`unic-normal`](https://crates.io/crates/unic-normal) crate.
++[`icu_normalizer`](https://crates.io/crates/icu_normalizer) crate.
+ 
+ The exception is windows-1258, which after normalizing to Unicode Normalization
+ Form C requires tone marks to be decomposed in order to minimize unmappable
+ characters. Vietnamese tone marks can be decomposed using the
+ [`detone`](https://crates.io/crates/detone) crate.
+ 
+ ## Licensing
+ 
+@@ -386,20 +386,19 @@ To regenerate the generated code:
+ 
+  * Have Python 2 installed.
+  * Clone [`https://github.com/hsivonen/encoding_c`](https://github.com/hsivonen/encoding_c)
+    next to the `encoding_rs` directory.
+  * Clone [`https://github.com/hsivonen/codepage`](https://github.com/hsivonen/codepage)
+    next to the `encoding_rs` directory.
+  * Clone [`https://github.com/whatwg/encoding`](https://github.com/whatwg/encoding)
+    next to the `encoding_rs` directory.
+- * Checkout revision `be3337450e7df1c49dca7872153c4c4670dd8256` of the `encoding` repo.
++ * Checkout revision `1d519bf8e5555cef64cf3a712485f41cd1a6a990` of the `encoding` repo.
+    (Note: `f381389` was the revision of `encoding` used from before the `encoding` repo
+-   license change. So far, only output changed since then has been updated to
+-   the new license legend.)
++   license change.)
+  * With the `encoding_rs` directory as the working directory, run
+    `python generate-encoding-data.py`.
+ 
+ ## Roadmap
+ 
+ - [x] Design the low-level API.
+ - [x] Provide Rust-only convenience features.
+ - [x] Provide an stl/gsl-flavored C++ API.
+@@ -433,16 +432,20 @@ To regenerate the generated code:
+ - [x] Add actually fast CJK encode options.
+ - [ ] ~Investigate [Bob Steagall's lookup table acceleration for UTF-8](https://github.com/BobSteagall/CppNow2018/blob/master/FastConversionFromUTF-8/Fast%20Conversion%20From%20UTF-8%20with%20C%2B%2B%2C%20DFAs%2C%20and%20SSE%20Intrinsics%20-%20Bob%20Steagall%20-%20C%2B%2BNow%202018.pdf).~
+ - [x] Provide a build mode that works without `alloc` (with lesser API surface).
+ - [x] Migrate to `std::simd` ~once it is stable and declare 1.0.~
+ - [ ] Migrate `unsafe` slice access by larger types than `u8`/`u16` to `align_to`.
+ 
+ ## Release Notes
+ 
++### 0.8.35
++
++* Implement changes for GB18030-2022. (Intentionally not treated as a semver break in practice even if this could be argued to be a breaking change in theory.)
++
+ ### 0.8.34
+ 
+ * Use the `portable_simd` nightly feature of the standard library instead of the `packed_simd` crate. Only affects the `simd-accel` optional nightly feature.
+ * Internal documentation improvements and minor code improvements around `unsafe`.
+ * Added `rust-version` to `Cargo.toml`.
+ 
+ ### 0.8.33
+ 
+diff --git a/third_party/rust/encoding_rs/doc/GBK.txt b/third_party/rust/encoding_rs/doc/GBK.txt
+--- a/third_party/rust/encoding_rs/doc/GBK.txt
++++ b/third_party/rust/encoding_rs/doc/GBK.txt
+@@ -1,13 +1,14 @@
+ /// The decoder for this encoding is the same as the decoder for gb18030.
+ /// The encoder side of this encoding is GBK with Windows code page 936 euro
+-/// sign behavior. GBK extends GB2312-80 to cover the CJK Unified Ideographs
+-/// Unicode block as well as a handful of ideographs from the CJK Unified
+-/// Ideographs Extension A and CJK Compatibility Ideographs blocks.
++/// sign behavior and with the changes to two-byte sequences made in GB18030-2022.
++/// GBK extends GB2312-80 to cover the CJK Unified Ideographs Unicode block as
++/// well as a handful of ideographs from the CJK Unified Ideographs Extension A
++/// and CJK Compatibility Ideographs blocks.
+ ///
+ /// Unlike e.g. in the case of ISO-8859-1 and windows-1252, GBK encoder wasn't
+ /// unified with the gb18030 encoder in the Encoding Standard out of concern
+ /// that servers that expect GBK form submissions might not be able to handle
+ /// the four-byte sequences.
+ ///
+ /// [Index visualization for the two-byte sequences](https://encoding.spec.whatwg.org/gb18030.html),
+ /// [Visualization of BMP coverage of the two-byte index](https://encoding.spec.whatwg.org/gb18030-bmp.html)
+diff --git a/third_party/rust/encoding_rs/doc/gb18030.txt b/third_party/rust/encoding_rs/doc/gb18030.txt
+--- a/third_party/rust/encoding_rs/doc/gb18030.txt
++++ b/third_party/rust/encoding_rs/doc/gb18030.txt
+@@ -1,9 +1,10 @@
+-/// This encoding matches GB18030-2005 except the two-byte sequence 0xA3 0xA0
+-/// maps to U+3000 for compatibility with existing Web content. As a result,
+-/// this encoding can represent all of Unicode except for the private-use
+-/// character U+E5E5.
++/// This encoding matches GB18030-2022 except the two-byte sequence 0xA3 0xA0
++/// maps to U+3000 for compatibility with existing Web content and the four-byte
++/// sequences for the non-PUA characters that got two-byte sequences still decode
++/// to the same non-PUA characters as in GB18030-2005. As a result, this encoding
++/// can represent all of Unicode except for 19 private-use characters.
+ ///
+ /// [Index visualization for the two-byte sequences](https://encoding.spec.whatwg.org/gb18030.html),
+ /// [Visualization of BMP coverage of the two-byte index](https://encoding.spec.whatwg.org/gb18030-bmp.html)
+ ///
+ /// This encoding matches the Windows code page 54936.
+diff --git a/third_party/rust/encoding_rs/generate-encoding-data.py b/third_party/rust/encoding_rs/generate-encoding-data.py
+--- a/third_party/rust/encoding_rs/generate-encoding-data.py
++++ b/third_party/rust/encoding_rs/generate-encoding-data.py
+@@ -10,17 +10,17 @@
+ # except according to those terms.
+ 
+ import json
+ import subprocess
+ import sys
+ import os.path
+ 
+ if (not os.path.isfile("../encoding/encodings.json")) or (not os.path.isfile("../encoding/indexes.json")):
+-  sys.stderr.write("This script needs a clone of https://github.com/whatwg/encoding/ (preferably at revision f381389) next to the encoding_rs directory.\n");
++  sys.stderr.write("This script needs a clone of https://github.com/whatwg/encoding/ (preferably at revision 1d519bf8e5555cef64cf3a712485f41cd1a6a990 ) next to the encoding_rs directory.\n");
+   sys.exit(-1)
+ 
+ if not os.path.isfile("../encoding_c/src/lib.rs"):
+   sys.stderr.write("This script also writes the generated parts of the encoding_c crate and needs a clone of https://github.com/hsivonen/encoding_c next to the encoding_rs directory.\n");
+   sys.exit(-1)
+ 
+ if not os.path.isfile("../codepage/src/lib.rs"):
+   sys.stderr.write("This script also writes the generated parts of the codepage crate and needs a clone of https://github.com/hsivonen/codepage next to the encoding_rs directory.\n");
+@@ -1607,18 +1607,17 @@ utf_8_file.write("""
+ 
+ """)
+ 
+ utf_8_file.write(utf_8_rs_end)
+ utf_8_file.close()
+ 
+ # Unit tests
+ 
+-TEST_HEADER = '''Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++TEST_HEADER = '''Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ '''
+ 
+ index = indexes["jis0208"]
+ 
+ jis0208_in_file = open("src/test_data/jis0208_in.txt", "w")
+diff --git a/third_party/rust/encoding_rs/src/data.rs b/third_party/rust/encoding_rs/src/data.rs
+--- a/third_party/rust/encoding_rs/src/data.rs
++++ b/third_party/rust/encoding_rs/src/data.rs
+@@ -2,16 +2,47 @@
+ // file at the top-level directory of this distribution.
+ //
+ // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ // option. This file may not be copied, modified, or distributed
+ // except according to those terms.
+ 
++// The above license applies to code in this file. The data in this
++// file is generated from WHATWG's indexes.json, which came under
++// the following license:
++
++// Copyright Â© WHATWG (Apple, Google, Mozilla, Microsoft).
++//
++// Redistribution and use in source and binary forms, with or without
++// modification, are permitted provided that the following conditions are met:
++//
++// 1. Redistributions of source code must retain the above copyright notice, this
++//    list of conditions and the following disclaimer.
++//
++// 2. Redistributions in binary form must reproduce the above copyright notice,
++//    this list of conditions and the following disclaimer in the documentation
++//    and/or other materials provided with the distribution.
++//
++// 3. Neither the name of the copyright holder nor the names of its
++//    contributors may be used to endorse or promote products derived from
++//    this software without specific prior written permission.
++//
++// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
++// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
++// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
+ // BEGIN GENERATED CODE. PLEASE DO NOT EDIT.
+ // Instead, please regenerate using generate-encoding-data.py
+ 
+ #[repr(align(64))] // Align to cache lines
+ pub struct SingleByteData {
+     pub ibm866: [u16; 128],
+     pub iso_8859_2: [u16; 128],
+     pub iso_8859_3: [u16; 128],
+@@ -88056,23 +88087,23 @@ pub static GBK_OTHER_UNSORTED_OFFSETS: [
+     0x2295, 0x3012, 0x301D, 0xE7BC, 0x3021, 0x32A3, 0x338E, 0x339C, 0x33A1, 0x33C4, 0x33CE, 0x33D1,
+     0x33D5, 0xFE30, 0xFFE2, 0xFFE4, 0xE7E2, 0x2121, 0x3231, 0xE7E3, 0x2010, 0xE7E4, 0x30FC, 0x309B,
+     0x30FD, 0x3006, 0x309D, 0xFE49, 0xFE54, 0xFE59, 0xFE68, 0x303E, 0x2FF0, 0x3007, 0xE7F4,
+ ];
+ 
+ pub static GBK_BOTTOM: [u16; 101] = [
+     0xF92C, 0xF979, 0xF995, 0xF9E7, 0xF9F1, 0xFA0C, 0xFA0D, 0xFA0E, 0xFA0F, 0xFA11, 0xFA13, 0xFA14,
+     0xFA18, 0xFA1F, 0xFA20, 0xFA21, 0xFA23, 0xFA24, 0xFA27, 0xFA28, 0xFA29, 0x2E81, 0xE816, 0xE817,
+-    0xE818, 0x2E84, 0x3473, 0x3447, 0x2E88, 0x2E8B, 0xE81E, 0x359E, 0x361A, 0x360E, 0x2E8C, 0x2E97,
+-    0x396E, 0x3918, 0xE826, 0x39CF, 0x39DF, 0x3A73, 0x39D0, 0xE82B, 0xE82C, 0x3B4E, 0x3C6E, 0x3CE0,
+-    0x2EA7, 0xE831, 0xE832, 0x2EAA, 0x4056, 0x415F, 0x2EAE, 0x4337, 0x2EB3, 0x2EB6, 0x2EB7, 0xE83B,
+-    0x43B1, 0x43AC, 0x2EBB, 0x43DD, 0x44D6, 0x4661, 0x464C, 0xE843, 0x4723, 0x4729, 0x477C, 0x478D,
++    0xE818, 0x2E84, 0x3473, 0x3447, 0x2E88, 0x2E8B, 0x9FB4, 0x359E, 0x361A, 0x360E, 0x2E8C, 0x2E97,
++    0x396E, 0x3918, 0x9FB5, 0x39CF, 0x39DF, 0x3A73, 0x39D0, 0x9FB6, 0x9FB7, 0x3B4E, 0x3C6E, 0x3CE0,
++    0x2EA7, 0xE831, 0x9FB8, 0x2EAA, 0x4056, 0x415F, 0x2EAE, 0x4337, 0x2EB3, 0x2EB6, 0x2EB7, 0xE83B,
++    0x43B1, 0x43AC, 0x2EBB, 0x43DD, 0x44D6, 0x4661, 0x464C, 0x9FB9, 0x4723, 0x4729, 0x477C, 0x478D,
+     0x2ECA, 0x4947, 0x497A, 0x497D, 0x4982, 0x4983, 0x4985, 0x4986, 0x499F, 0x499B, 0x49B7, 0x49B6,
+-    0xE854, 0xE855, 0x4CA3, 0x4C9F, 0x4CA0, 0x4CA1, 0x4C77, 0x4CA2, 0x4D13, 0x4D14, 0x4D15, 0x4D16,
+-    0x4D17, 0x4D18, 0x4D19, 0x4DAE, 0xE864,
++    0x9FBA, 0xE855, 0x4CA3, 0x4C9F, 0x4CA0, 0x4CA1, 0x4C77, 0x4CA2, 0x4D13, 0x4D14, 0x4D15, 0x4D16,
++    0x4D17, 0x4D18, 0x4D19, 0x4DAE, 0x9FBB,
+ ];
+ 
+ pub static GB2312_HANZI: [u16; 6768] = [
+     0x554A, 0x963F, 0x57C3, 0x6328, 0x54CE, 0x5509, 0x54C0, 0x7691, 0x764C, 0x853C, 0x77EE, 0x827E,
+     0x788D, 0x7231, 0x9698, 0x978D, 0x6C28, 0x5B89, 0x4FFA, 0x6309, 0x6697, 0x5CB8, 0x80FA, 0x6848,
+     0x80AE, 0x6602, 0x76CE, 0x51F9, 0x6556, 0x71AC, 0x7FF1, 0x8884, 0x50B2, 0x5965, 0x61CA, 0x6FB3,
+     0x82AD, 0x634C, 0x6252, 0x53ED, 0x5427, 0x7B06, 0x516B, 0x75A4, 0x5DF4, 0x62D4, 0x8DCB, 0x9776,
+     0x628A, 0x8019, 0x575D, 0x9738, 0x7F62, 0x7238, 0x767D, 0x67CF, 0x767E, 0x6446, 0x4F70, 0x8D25,
+@@ -88645,37 +88676,37 @@ pub static GB2312_SYMBOLS: [u16; 94] = [
+     0x2299, 0x222B, 0x222E, 0x2261, 0x224C, 0x2248, 0x223D, 0x221D, 0x2260, 0x226E, 0x226F, 0x2264,
+     0x2265, 0x221E, 0x2235, 0x2234, 0x2642, 0x2640, 0x00B0, 0x2032, 0x2033, 0x2103, 0xFF04, 0x00A4,
+     0xFFE0, 0xFFE1, 0x2030, 0x00A7, 0x2116, 0x2606, 0x2605, 0x25CB, 0x25CF, 0x25CE, 0x25C7, 0x25C6,
+     0x25A1, 0x25A0, 0x25B3, 0x25B2, 0x203B, 0x2192, 0x2190, 0x2191, 0x2193, 0x3013,
+ ];
+ 
+ pub static GB2312_SYMBOLS_AFTER_GREEK: [u16; 22] = [
+     0xFE35, 0xFE36, 0xFE39, 0xFE3A, 0xFE3F, 0xFE40, 0xFE3D, 0xFE3E, 0xFE41, 0xFE42, 0xFE43, 0xFE44,
+-    0xE794, 0xE795, 0xFE3B, 0xFE3C, 0xFE37, 0xFE38, 0xFE31, 0xE796, 0xFE33, 0xFE34,
++    0xFE17, 0xFE18, 0xFE3B, 0xFE3C, 0xFE37, 0xFE38, 0xFE31, 0xFE19, 0xFE33, 0xFE34,
+ ];
+ 
+ pub static GB2312_PINYIN: [u16; 32] = [
+     0x0101, 0x00E1, 0x01CE, 0x00E0, 0x0113, 0x00E9, 0x011B, 0x00E8, 0x012B, 0x00ED, 0x01D0, 0x00EC,
+     0x014D, 0x00F3, 0x01D2, 0x00F2, 0x016B, 0x00FA, 0x01D4, 0x00F9, 0x01D6, 0x01D8, 0x01DA, 0x01DC,
+     0x00FC, 0x00EA, 0x0251, 0x1E3F, 0x0144, 0x0148, 0x01F9, 0x0261,
+ ];
+ 
+-pub static GB2312_OTHER_POINTERS: [u16; 44] = [
++pub static GB2312_OTHER_POINTERS: [u16; 47] = [
+     0x0000, 0x000A, 0x0010, 0x0024, 0x0038, 0x0042, 0x0043, 0x0044, 0x004E, 0x0050, 0x005C, 0x005E,
+     0x0061, 0x0062, 0x00BB, 0x00BC, 0x010F, 0x011A, 0x0170, 0x0178, 0x0189, 0x0190, 0x0198, 0x01A9,
+-    0x01B0, 0x01B7, 0x01CD, 0x01D6, 0x01DC, 0x01DD, 0x01F7, 0x0206, 0x020C, 0x020D, 0x0227, 0x0234,
+-    0x0254, 0x0258, 0x027D, 0x0292, 0x0295, 0x02E1, 0x02F0, 0x0524,
++    0x01B0, 0x01B1, 0x01B2, 0x01B3, 0x01B7, 0x01CD, 0x01D6, 0x01DC, 0x01DD, 0x01F7, 0x0206, 0x020C,
++    0x020D, 0x0227, 0x0234, 0x0254, 0x0258, 0x027D, 0x0292, 0x0295, 0x02E1, 0x02F0, 0x0524,
+ ];
+ 
+-pub static GB2312_OTHER_UNSORTED_OFFSETS: [u16; 43] = [
++pub static GB2312_OTHER_UNSORTED_OFFSETS: [u16; 46] = [
+     0x2170, 0xE766, 0x2488, 0x2474, 0x2460, 0x20AC, 0xE76D, 0x3220, 0xE76E, 0x2160, 0xE770, 0xFF01,
+     0xFFE5, 0xFF05, 0xFFE3, 0x3041, 0xE772, 0x30A1, 0xE77D, 0x0391, 0x03A3, 0xE785, 0x03B1, 0x03C3,
+-    0xE78D, 0x0000, 0xE797, 0x0410, 0x0401, 0x0416, 0xE7A0, 0x0430, 0x0451, 0x0436, 0xE7AF, 0x0000,
+-    0xE7C9, 0x3105, 0xE7CD, 0xE7FE, 0x2500, 0xE801, 0xE000,
++    0xFE10, 0xFE12, 0xFE11, 0xFE13, 0x0000, 0xE797, 0x0410, 0x0401, 0x0416, 0xE7A0, 0x0430, 0x0451,
++    0x0436, 0xE7AF, 0x0000, 0xE7C9, 0x3105, 0xE7CD, 0xE7FE, 0x2500, 0xE801, 0xE000,
+ ];
+ 
+ pub static GB18030_RANGE_POINTERS: [u16; 206] = [
+     0x0000, 0x0024, 0x0026, 0x002D, 0x0032, 0x0051, 0x0059, 0x005F, 0x0060, 0x0064, 0x0067, 0x0068,
+     0x0069, 0x006D, 0x007E, 0x0085, 0x0094, 0x00AC, 0x00AF, 0x00B3, 0x00D0, 0x0132, 0x0133, 0x0134,
+     0x0135, 0x0136, 0x0137, 0x0138, 0x0139, 0x0155, 0x01AC, 0x01BB, 0x0220, 0x0221, 0x022E, 0x02E5,
+     0x02E6, 0x02ED, 0x02EE, 0x0325, 0x0333, 0x0334, 0x1EF2, 0x1EF4, 0x1EF5, 0x1EF7, 0x1EFE, 0x1F07,
+     0x1F08, 0x1F09, 0x1F0E, 0x1F7E, 0x1FD4, 0x1FD5, 0x1FD8, 0x1FE4, 0x1FEE, 0x202C, 0x2030, 0x2046,
+diff --git a/third_party/rust/encoding_rs/src/gb18030.rs b/third_party/rust/encoding_rs/src/gb18030.rs
+--- a/third_party/rust/encoding_rs/src/gb18030.rs
++++ b/third_party/rust/encoding_rs/src/gb18030.rs
+@@ -4,16 +4,17 @@
+ // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ // option. This file may not be copied, modified, or distributed
+ // except according to those terms.
+ 
+ use super::*;
+ use crate::data::*;
++use crate::gb18030_2022::*;
+ use crate::handles::*;
+ use crate::variant::*;
+ // Rust 1.14.0 requires the following despite the asterisk above.
+ use super::in_inclusive_range16;
+ use super::in_range16;
+ 
+ enum Gb18030Pending {
+     None,
+@@ -342,18 +343,25 @@ fn gbk_encode_non_unified(bmp: u16) -> O
+         {
+             // Diacritics and Latin 1 symbols
+             if let Some(pos) = position(&GB2312_SYMBOLS[3..(0xAC - 0x60)], bmp) {
+                 return Some((0xA1, pos + 0xA1 + 3));
+             }
+         }
+         return None;
+     }
+-    if bmp >= 0xE794 {
+-        // Various brackets, all in PUA or full-width regions
++
++    if in_inclusive_range16(bmp, 0xE78D, 0xE864) {
++        // The array is sorted but short, so let's do linear search.
++        if let Some(pos) = position(&GB18030_2022_OVERRIDE_PUA[..], bmp) {
++            let pair = &GB18030_2022_OVERRIDE_BYTES[pos];
++            return Some((pair[0].into(), pair[1].into()));
++        }
++    } else if bmp >= 0xFE17 {
++        // Various brackets, all in full-width regions
+         if let Some(pos) = position(&GB2312_SYMBOLS_AFTER_GREEK[..], bmp) {
+             return Some((0xA6, pos + (0x9F - 0x60 + 0xA1)));
+         }
+     } else if bmp == 0x1E3F {
+         // The one Pinyin placed elsewhere on the BMP
+         return Some((0xA8, 0x7B - 0x60 + 0xA1));
+     } else if in_range16(bmp, 0xA000, 0xD800) {
+         // Since Korean has usage in China, let's spend a branch to fast-track
+@@ -375,18 +383,21 @@ fn gbk_encode_non_unified(bmp: u16) -> O
+     }
+     // GBK other (except radicals and PUA in GBK_BOTTOM).
+     if let Some(other_pointer) = gbk_other_encode(bmp) {
+         let other_lead = other_pointer as usize / (190 - 94);
+         let other_trail = other_pointer as usize % (190 - 94);
+         let offset = if other_trail < 0x3F { 0x40 } else { 0x41 };
+         return Some((other_lead + (0x81 + 0x20), other_trail + offset));
+     }
+-    // CJK Radicals Supplement or PUA in GBK_BOTTOM
+-    if in_inclusive_range16(bmp, 0x2E81, 0x2ECA) || in_inclusive_range16(bmp, 0xE816, 0xE864) {
++    // CJK Radicals Supplement, PUA, and U+9FBx ideographs in GBK_BOTTOM
++    if in_inclusive_range16(bmp, 0x2E81, 0x2ECA)
++        || in_inclusive_range16(bmp, 0x9FB4, 0x9FBB)
++        || in_inclusive_range16(bmp, 0xE816, 0xE855)
++    {
+         if let Some(pos) = position(&GBK_BOTTOM[21..], bmp) {
+             let trail = pos + 16;
+             let offset = if trail < 0x3F { 0x40 } else { 0x41 };
+             return Some((0xFE, trail + offset));
+         }
+     }
+     // GB2312 bottom PUA
+     let bmp_minus_gb2312_bottom_pua = bmp.wrapping_sub(0xE234);
+@@ -602,21 +613,28 @@ mod tests {
+ 
+         // two bytes
+         decode_gb18030(b"\x81\x40", "\u{4E02}");
+         decode_gb18030(b"\x81\x7E", "\u{4E8A}");
+         decode_gb18030(b"\x81\x7F", "\u{FFFD}\u{007F}");
+         decode_gb18030(b"\x81\x80", "\u{4E90}");
+         decode_gb18030(b"\x81\xFE", "\u{4FA2}");
+         decode_gb18030(b"\xFE\x40", "\u{FA0C}");
+-        decode_gb18030(b"\xFE\x7E", "\u{E843}");
+         decode_gb18030(b"\xFE\x7F", "\u{FFFD}\u{007F}");
+         decode_gb18030(b"\xFE\x80", "\u{4723}");
+         decode_gb18030(b"\xFE\xFE", "\u{E4C5}");
+ 
++        // Changes between GB18030-2005 and GB18030-2022
++        decode_gb18030(b"\xFE\x7E", "\u{9FB9}");
++        decode_gb18030(b"\xA6\xDD", "\u{FE14}");
++
++        // These mappings remain in place the GB18030-2005 way despite GB18030-2022
++        decode_gb18030(b"\x82\x35\x91\x32", "\u{9FB9}");
++        decode_gb18030(b"\x84\x31\x83\x30", "\u{FE14}");
++
+         // The difference from the original GB18030
+         decode_gb18030(b"\xA3\xA0", "\u{3000}");
+         decode_gb18030(b"\xA1\xA1", "\u{3000}");
+ 
+         // 0xFF
+         decode_gb18030(b"\xFF\x40", "\u{FFFD}\u{0040}");
+         decode_gb18030(b"\xE3\xFF\x9A\x33", "\u{FFFD}\u{FFFD}"); // not \u{FFFD}\u{FFFD}\u{0033} !
+         decode_gb18030(b"\xFF\x32\x9A\x33", "\u{FFFD}\u{0032}\u{FFFD}"); // not \u{FFFD}\u{0032}\u{FFFD}\u{0033} !
+@@ -674,16 +692,25 @@ mod tests {
+             // Miri is too slow
+             encode_gb18030("\u{2603}", b"\x81\x37\xA3\x30");
+             encode_gb18030("\u{1F4A9}", b"\x94\x39\xDA\x33");
+             encode_gb18030("\u{10FFFF}", b"\xE3\x32\x9A\x35");
+         }
+ 
+         // Edge cases
+         encode_gb18030("\u{00F7}", b"\xA1\xC2");
++
++        // GB18030-2022
++        encode_gb18030("\u{9FB9}", b"\xFE\x7E");
++        encode_gb18030("\u{FE14}", b"\xA6\xDD");
++        encode_gb18030("\u{E843}", b"\xFE\x7E");
++        encode_gb18030("\u{E791}", b"\xA6\xDD");
++
++        // Non-change in GB18030-2022
++        encode_gb18030("\u{E817}", b"\xFE\x52");
+     }
+ 
+     #[test]
+     fn test_gbk_encode() {
+         // Empty
+         encode_gbk("", b"");
+ 
+         // ASCII
+@@ -716,16 +743,25 @@ mod tests {
+             // Miri is too slow
+             encode_gbk("\u{2603}", b"&#9731;");
+             encode_gbk("\u{1F4A9}", b"&#128169;");
+             encode_gbk("\u{10FFFF}", b"&#1114111;");
+         }
+ 
+         // Edge cases
+         encode_gbk("\u{00F7}", b"\xA1\xC2");
++
++        // GB18030-2022
++        encode_gb18030("\u{9FB9}", b"\xFE\x7E");
++        encode_gb18030("\u{FE14}", b"\xA6\xDD");
++        encode_gb18030("\u{E843}", b"\xFE\x7E");
++        encode_gb18030("\u{E791}", b"\xA6\xDD");
++
++        // Non-change in GB18030-2022
++        encode_gb18030("\u{E817}", b"\xFE\x52");
+     }
+ 
+     #[test]
+     #[cfg_attr(miri, ignore)] // Miri is too slow
+     fn test_gb18030_decode_all() {
+         let input = include_bytes!("test_data/gb18030_in.txt");
+         let expectation = include_str!("test_data/gb18030_in_ref.txt");
+         let (cow, had_errors) = GB18030.decode_without_bom_handling(input);
+diff --git a/third_party/rust/encoding_rs/src/gb18030_2022.rs b/third_party/rust/encoding_rs/src/gb18030_2022.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/encoding_rs/src/gb18030_2022.rs
+@@ -0,0 +1,54 @@
++// Copyright Â© WHATWG (Apple, Google, Mozilla, Microsoft).
++//
++// Redistribution and use in source and binary forms, with or without
++// modification, are permitted provided that the following conditions are met:
++//
++// 1. Redistributions of source code must retain the above copyright notice, this
++//    list of conditions and the following disclaimer.
++//
++// 2. Redistributions in binary form must reproduce the above copyright notice,
++//    this list of conditions and the following disclaimer in the documentation
++//    and/or other materials provided with the distribution.
++//
++// 3. Neither the name of the copyright holder nor the names of its
++//    contributors may be used to endorse or promote products derived from
++//    this software without specific prior written permission.
++//
++// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
++// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
++// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
++/// The PUA code points special-cased in the GB18030 encoder.
++pub(crate) static GB18030_2022_OVERRIDE_PUA: [u16; 18] = [
++    0xE78D, 0xE78E, 0xE78F, 0xE790, 0xE791, 0xE792, 0xE793, 0xE794, 0xE795, 0xE796, 0xE81E, 0xE826,
++    0xE82B, 0xE82C, 0xE832, 0xE843, 0xE854, 0xE864,
++];
++
++/// The bytes corresponding to the PUA code points special-cased in the GB18030 encoder.
++pub(crate) static GB18030_2022_OVERRIDE_BYTES: [[u8; 2]; 18] = [
++    [0xA6, 0xD9],
++    [0xA6, 0xDA],
++    [0xA6, 0xDB],
++    [0xA6, 0xDC],
++    [0xA6, 0xDD],
++    [0xA6, 0xDE],
++    [0xA6, 0xDF],
++    [0xA6, 0xEC],
++    [0xA6, 0xED],
++    [0xA6, 0xF3],
++    [0xFE, 0x59],
++    [0xFE, 0x61],
++    [0xFE, 0x66],
++    [0xFE, 0x67],
++    [0xFE, 0x6D],
++    [0xFE, 0x7E],
++    [0xFE, 0x90],
++    [0xFE, 0xA0],
++];
+diff --git a/third_party/rust/encoding_rs/src/lib.rs b/third_party/rust/encoding_rs/src/lib.rs
+--- a/third_party/rust/encoding_rs/src/lib.rs
++++ b/third_party/rust/encoding_rs/src/lib.rs
+@@ -2,16 +2,47 @@
+ // file at the top-level directory of this distribution.
+ //
+ // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ // option. This file may not be copied, modified, or distributed
+ // except according to those terms.
+ 
++// The above license applies to code in this file. The label data in
++// this file is generated from WHATWG's encodings.json, which came under
++// the following license:
++
++// Copyright Â© WHATWG (Apple, Google, Mozilla, Microsoft).
++//
++// Redistribution and use in source and binary forms, with or without
++// modification, are permitted provided that the following conditions are met:
++//
++// 1. Redistributions of source code must retain the above copyright notice, this
++//    list of conditions and the following disclaimer.
++//
++// 2. Redistributions in binary form must reproduce the above copyright notice,
++//    this list of conditions and the following disclaimer in the documentation
++//    and/or other materials provided with the distribution.
++//
++// 3. Neither the name of the copyright holder nor the names of its
++//    contributors may be used to endorse or promote products derived from
++//    this software without specific prior written permission.
++//
++// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
++// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
++// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
+ #![cfg_attr(
+     feature = "cargo-clippy",
+     allow(doc_markdown, inline_always, new_ret_no_self)
+ )]
+ 
+ //! encoding_rs is a Gecko-oriented Free Software / Open Source implementation
+ //! of the [Encoding Standard](https://encoding.spec.whatwg.org/) in Rust.
+ //! Gecko-oriented means that converting to and from UTF-16 is supported in
+@@ -725,16 +756,17 @@ mod simd_funcs;
+ 
+ #[cfg(all(test, feature = "alloc"))]
+ mod testing;
+ 
+ mod big5;
+ mod euc_jp;
+ mod euc_kr;
+ mod gb18030;
++mod gb18030_2022;
+ mod iso_2022_jp;
+ mod replacement;
+ mod shift_jis;
+ mod single_byte;
+ mod utf_16;
+ mod utf_8;
+ mod x_user_defined;
+ 
+@@ -909,19 +941,20 @@ pub static GBK_INIT: Encoding = Encoding
+     name: "GBK",
+     variant: VariantEncoding::Gbk,
+ };
+ 
+ /// The GBK encoding.
+ ///
+ /// The decoder for this encoding is the same as the decoder for gb18030.
+ /// The encoder side of this encoding is GBK with Windows code page 936 euro
+-/// sign behavior. GBK extends GB2312-80 to cover the CJK Unified Ideographs
+-/// Unicode block as well as a handful of ideographs from the CJK Unified
+-/// Ideographs Extension A and CJK Compatibility Ideographs blocks.
++/// sign behavior and with the changes to two-byte sequences made in GB18030-2022.
++/// GBK extends GB2312-80 to cover the CJK Unified Ideographs Unicode block as
++/// well as a handful of ideographs from the CJK Unified Ideographs Extension A
++/// and CJK Compatibility Ideographs blocks.
+ ///
+ /// Unlike e.g. in the case of ISO-8859-1 and windows-1252, GBK encoder wasn't
+ /// unified with the gb18030 encoder in the Encoding Standard out of concern
+ /// that servers that expect GBK form submissions might not be able to handle
+ /// the four-byte sequences.
+ ///
+ /// [Index visualization for the two-byte sequences](https://encoding.spec.whatwg.org/gb18030.html),
+ /// [Visualization of BMP coverage of the two-byte index](https://encoding.spec.whatwg.org/gb18030-bmp.html)
+@@ -1653,20 +1686,21 @@ pub static UTF_8: &'static Encoding = &U
+ /// items.
+ pub static GB18030_INIT: Encoding = Encoding {
+     name: "gb18030",
+     variant: VariantEncoding::Gb18030,
+ };
+ 
+ /// The gb18030 encoding.
+ ///
+-/// This encoding matches GB18030-2005 except the two-byte sequence 0xA3 0xA0
+-/// maps to U+3000 for compatibility with existing Web content. As a result,
+-/// this encoding can represent all of Unicode except for the private-use
+-/// character U+E5E5.
++/// This encoding matches GB18030-2022 except the two-byte sequence 0xA3 0xA0
++/// maps to U+3000 for compatibility with existing Web content and the four-byte
++/// sequences for the non-PUA characters that got two-byte sequences still decode
++/// to the same non-PUA characters as in GB18030-2005. As a result, this encoding
++/// can represent all of Unicode except for 19 private-use characters.
+ ///
+ /// [Index visualization for the two-byte sequences](https://encoding.spec.whatwg.org/gb18030.html),
+ /// [Visualization of BMP coverage of the two-byte index](https://encoding.spec.whatwg.org/gb18030-bmp.html)
+ ///
+ /// This encoding matches the Windows code page 54936.
+ ///
+ /// This will change from `static` to `const` if Rust changes
+ /// to make the referent of `pub const FOO: &'static Encoding`
+diff --git a/third_party/rust/encoding_rs/src/test_data/big5_in.txt b/third_party/rust/encoding_rs/src/test_data/big5_in.txt
+--- a/third_party/rust/encoding_rs/src/test_data/big5_in.txt
++++ b/third_party/rust/encoding_rs/src/test_data/big5_in.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ @
+ A
+ B
+ C
+ D
+diff --git a/third_party/rust/encoding_rs/src/test_data/big5_in_ref.txt b/third_party/rust/encoding_rs/src/test_data/big5_in_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/big5_in_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/big5_in_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ï¿œ@
+ ï¿œA
+ ï¿œB
+ ï¿œC
+ ï¿œD
+diff --git a/third_party/rust/encoding_rs/src/test_data/big5_out.txt b/third_party/rust/encoding_rs/src/test_data/big5_out.txt
+--- a/third_party/rust/encoding_rs/src/test_data/big5_out.txt
++++ b/third_party/rust/encoding_rs/src/test_data/big5_out.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ã
+ ïŒ
+ ã
+ ã
+ ïŒ
+diff --git a/third_party/rust/encoding_rs/src/test_data/big5_out_ref.txt b/third_party/rust/encoding_rs/src/test_data/big5_out_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/big5_out_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/big5_out_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ¡@
+ ¡A
+ ¡B
+ ¡C
+ ¡D
+diff --git a/third_party/rust/encoding_rs/src/test_data/euc_kr_in.txt b/third_party/rust/encoding_rs/src/test_data/euc_kr_in.txt
+--- a/third_party/rust/encoding_rs/src/test_data/euc_kr_in.txt
++++ b/third_party/rust/encoding_rs/src/test_data/euc_kr_in.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ A
+ B
+ C
+ D
+ E
+diff --git a/third_party/rust/encoding_rs/src/test_data/euc_kr_in_ref.txt b/third_party/rust/encoding_rs/src/test_data/euc_kr_in_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/euc_kr_in_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/euc_kr_in_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ê°
+ ê°
+ ê°
+ ê°
+ ê°
+diff --git a/third_party/rust/encoding_rs/src/test_data/euc_kr_out.txt b/third_party/rust/encoding_rs/src/test_data/euc_kr_out.txt
+--- a/third_party/rust/encoding_rs/src/test_data/euc_kr_out.txt
++++ b/third_party/rust/encoding_rs/src/test_data/euc_kr_out.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ê°
+ ê°
+ ê°
+ ê°
+ ê°
+diff --git a/third_party/rust/encoding_rs/src/test_data/euc_kr_out_ref.txt b/third_party/rust/encoding_rs/src/test_data/euc_kr_out_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/euc_kr_out_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/euc_kr_out_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ A
+ B
+ C
+ D
+ E
+diff --git a/third_party/rust/encoding_rs/src/test_data/gb18030_in.txt b/third_party/rust/encoding_rs/src/test_data/gb18030_in.txt
+--- a/third_party/rust/encoding_rs/src/test_data/gb18030_in.txt
++++ b/third_party/rust/encoding_rs/src/test_data/gb18030_in.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ @
+ A
+ B
+ C
+ D
+diff --git a/third_party/rust/encoding_rs/src/test_data/gb18030_in_ref.txt b/third_party/rust/encoding_rs/src/test_data/gb18030_in_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/gb18030_in_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/gb18030_in_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ äž
+ äž
+ äž
+ äž
+ äž
+@@ -7180,43 +7179,43 @@ Instead, please regenerate using generat
+ Ï
+ Ï
+ Ï
+ Ï
+ Ï
+ Ï
+ Ï
+ Ï
+-î
+-î
+-î
+-î
+-î
+-î
+-î
++ïž
++ïž
++ïž
++ïž
++ïž
++ïž
++ïž
+ ïžµ
+ ïž¶
+ ïž¹
+ ïžº
+ ïž¿
+ ï¹
+ ïžœ
+ ïžŸ
+ ï¹
+ ï¹
+ ï¹
+ ï¹
+-î
+-î
++ïž
++ïž
+ ïž»
+ ïžŒ
+ ïž·
+ ïžž
+ ïž±
+-î
++ïž
+ ïž³
+ ïžŽ
+ î
+ î
+ î
+ î
+ î
+ î
+@@ -23773,87 +23772,87 @@ Instead, please regenerate using generat
+ î 
+ î 
+ î 
+ âº
+ ã³
+ ã
+ âº
+ âº
+-î 
++éŸŽ
+ ã
+ ã
+ ã
+ âº
+ âº
+ ã¥®
+ ã€
+-î Š
++éŸµ
+ ã§
+ ã§
+ ã©³
+ ã§
+-î «
+-î ¬
++éŸ¶
++éŸ·
+ ã­
+ ã±®
+ ã³ 
+ âº§
+ î ±
+-î ²
++éŸž
+ âºª
+ ä
+ ä
+ âº®
+ ä·
+ âº³
+ âº¶
+ âº·
+ î »
+ ä±
+ ä¬
+ âº»
+ ä
+ ä
+ ä¡
+ ä
+-î¡
++éŸ¹
+ ä£
+ ä©
+ äŒ
+ ä
+ â»
+ ä¥
+ ä¥º
+ ä¥œ
+ äŠ
+ äŠ
+ äŠ
+ äŠ
+ äŠ
+ äŠ
+ äŠ·
+ äŠ¶
+-î¡
++éŸº
+ î¡
+ ä²£
+ ä²
+ ä² 
+ ä²¡
+ ä±·
+ ä²¢
+ äŽ
+ äŽ
+ äŽ
+ äŽ
+ äŽ
+ äŽ
+ äŽ
+ ä¶®
+-î¡€
++éŸ»
+ îš
+ î©
+ îª
+ î«
+ î¬
+ î­
+ î®
+ î¯
+diff --git a/third_party/rust/encoding_rs/src/test_data/gb18030_out.txt b/third_party/rust/encoding_rs/src/test_data/gb18030_out.txt
+--- a/third_party/rust/encoding_rs/src/test_data/gb18030_out.txt
++++ b/third_party/rust/encoding_rs/src/test_data/gb18030_out.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ äž
+ äž
+ äž
+ äž
+ äž
+@@ -7179,43 +7178,43 @@ Instead, please regenerate using generat
+ Ï
+ Ï
+ Ï
+ Ï
+ Ï
+ Ï
+ Ï
+ Ï
+-î
+-î
+-î
+-î
+-î
+-î
+-î
++ïž
++ïž
++ïž
++ïž
++ïž
++ïž
++ïž
+ ïžµ
+ ïž¶
+ ïž¹
+ ïžº
+ ïž¿
+ ï¹
+ ïžœ
+ ïžŸ
+ ï¹
+ ï¹
+ ï¹
+ ï¹
+-î
+-î
++ïž
++ïž
+ ïž»
+ ïžŒ
+ ïž·
+ ïžž
+ ïž±
+-î
++ïž
+ ïž³
+ ïžŽ
+ î
+ î
+ î
+ î
+ î
+ î
+@@ -23772,87 +23771,87 @@ Instead, please regenerate using generat
+ î 
+ î 
+ î 
+ âº
+ ã³
+ ã
+ âº
+ âº
+-î 
++éŸŽ
+ ã
+ ã
+ ã
+ âº
+ âº
+ ã¥®
+ ã€
+-î Š
++éŸµ
+ ã§
+ ã§
+ ã©³
+ ã§
+-î «
+-î ¬
++éŸ¶
++éŸ·
+ ã­
+ ã±®
+ ã³ 
+ âº§
+ î ±
+-î ²
++éŸž
+ âºª
+ ä
+ ä
+ âº®
+ ä·
+ âº³
+ âº¶
+ âº·
+ î »
+ ä±
+ ä¬
+ âº»
+ ä
+ ä
+ ä¡
+ ä
+-î¡
++éŸ¹
+ ä£
+ ä©
+ äŒ
+ ä
+ â»
+ ä¥
+ ä¥º
+ ä¥œ
+ äŠ
+ äŠ
+ äŠ
+ äŠ
+ äŠ
+ äŠ
+ äŠ·
+ äŠ¶
+-î¡
++éŸº
+ î¡
+ ä²£
+ ä²
+ ä² 
+ ä²¡
+ ä±·
+ ä²¢
+ äŽ
+ äŽ
+ äŽ
+ äŽ
+ äŽ
+ äŽ
+ äŽ
+ ä¶®
+-î¡€
++éŸ»
+ îš
+ î©
+ îª
+ î«
+ î¬
+ î­
+ î®
+ î¯
+diff --git a/third_party/rust/encoding_rs/src/test_data/gb18030_out_ref.txt b/third_party/rust/encoding_rs/src/test_data/gb18030_out_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/gb18030_out_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/gb18030_out_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ @
+ A
+ B
+ C
+ D
+diff --git a/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_in.txt b/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_in.txt
+--- a/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_in.txt
++++ b/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_in.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ $B!!(B
+ $B!"(B
+ $B!#(B
+ $B!$(B
+ $B!%(B
+diff --git a/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_in_ref.txt b/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_in_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_in_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_in_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ã
+ ã
+ ã
+ ïŒ
+ ïŒ
+diff --git a/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_out.txt b/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_out.txt
+--- a/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_out.txt
++++ b/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_out.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ã
+ ã
+ ã
+ ïŒ
+ ïŒ
+diff --git a/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_out_ref.txt b/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_out_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_out_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/iso_2022_jp_out_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ $B!!(B
+ $B!"(B
+ $B!#(B
+ $B!$(B
+ $B!%(B
+diff --git a/third_party/rust/encoding_rs/src/test_data/jis0208_in.txt b/third_party/rust/encoding_rs/src/test_data/jis0208_in.txt
+--- a/third_party/rust/encoding_rs/src/test_data/jis0208_in.txt
++++ b/third_party/rust/encoding_rs/src/test_data/jis0208_in.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ¡¡
+ ¡¢
+ ¡£
+ ¡€
+ ¡¥
+diff --git a/third_party/rust/encoding_rs/src/test_data/jis0208_in_ref.txt b/third_party/rust/encoding_rs/src/test_data/jis0208_in_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/jis0208_in_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/jis0208_in_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ã
+ ã
+ ã
+ ïŒ
+ ïŒ
+diff --git a/third_party/rust/encoding_rs/src/test_data/jis0208_out.txt b/third_party/rust/encoding_rs/src/test_data/jis0208_out.txt
+--- a/third_party/rust/encoding_rs/src/test_data/jis0208_out.txt
++++ b/third_party/rust/encoding_rs/src/test_data/jis0208_out.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ã
+ ã
+ ã
+ ïŒ
+ ïŒ
+diff --git a/third_party/rust/encoding_rs/src/test_data/jis0208_out_ref.txt b/third_party/rust/encoding_rs/src/test_data/jis0208_out_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/jis0208_out_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/jis0208_out_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ¡¡
+ ¡¢
+ ¡£
+ ¡€
+ ¡¥
+diff --git a/third_party/rust/encoding_rs/src/test_data/jis0212_in.txt b/third_party/rust/encoding_rs/src/test_data/jis0212_in.txt
+--- a/third_party/rust/encoding_rs/src/test_data/jis0212_in.txt
++++ b/third_party/rust/encoding_rs/src/test_data/jis0212_in.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ¡¡
+ ¡¢
+ ¡£
+ ¡€
+ ¡¥
+diff --git a/third_party/rust/encoding_rs/src/test_data/jis0212_in_ref.txt b/third_party/rust/encoding_rs/src/test_data/jis0212_in_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/jis0212_in_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/jis0212_in_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ï¿œ
+ ï¿œ
+ ï¿œ
+ ï¿œ
+ ï¿œ
+diff --git a/third_party/rust/encoding_rs/src/test_data/shift_jis_in.txt b/third_party/rust/encoding_rs/src/test_data/shift_jis_in.txt
+--- a/third_party/rust/encoding_rs/src/test_data/shift_jis_in.txt
++++ b/third_party/rust/encoding_rs/src/test_data/shift_jis_in.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ @
+ A
+ B
+ C
+ D
+diff --git a/third_party/rust/encoding_rs/src/test_data/shift_jis_in_ref.txt b/third_party/rust/encoding_rs/src/test_data/shift_jis_in_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/shift_jis_in_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/shift_jis_in_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ã
+ ã
+ ã
+ ïŒ
+ ïŒ
+diff --git a/third_party/rust/encoding_rs/src/test_data/shift_jis_out.txt b/third_party/rust/encoding_rs/src/test_data/shift_jis_out.txt
+--- a/third_party/rust/encoding_rs/src/test_data/shift_jis_out.txt
++++ b/third_party/rust/encoding_rs/src/test_data/shift_jis_out.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ ã
+ ã
+ ã
+ ïŒ
+ ïŒ
+diff --git a/third_party/rust/encoding_rs/src/test_data/shift_jis_out_ref.txt b/third_party/rust/encoding_rs/src/test_data/shift_jis_out_ref.txt
+--- a/third_party/rust/encoding_rs/src/test_data/shift_jis_out_ref.txt
++++ b/third_party/rust/encoding_rs/src/test_data/shift_jis_out_ref.txt
+@@ -1,10 +1,9 @@
+-Any copyright to the test code below this comment is dedicated to the
+-Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
++Generated from WHATWG indexes.json; see LICENSE-WHATWG.
+ 
+ This is a generated file. Please do not edit.
+ Instead, please regenerate using generate-encoding-data.py
+ @
+ A
+ B
+ C
+ D

--- a/seamonkey/6011-fix-rust-1.95.0-mozbg1882209-152a1.patch
+++ b/seamonkey/6011-fix-rust-1.95.0-mozbg1882209-152a1.patch
@@ -1,0 +1,197 @@
+# HG changeset patch
+# User Henri Sivonen <hsivonen@hsivonen.fi>
+# Date 1776755360 0
+# Node ID ec1dd05fd5785985b7bd9636405688d1d61a95d9
+# Parent  7577c472c3f18ca497ab92b15df7a01e7194ffd6
+Bug 2033279 - Make --enable-rust-simd work with Rust 1.95. r=firefox-build-system-reviewers,supply-chain-reviewers,ahochheiden
+
+Differential Revision: https://phabricator.services.mozilla.com/D295287
+
+diff --git a/.cargo/config.in b/.cargo/config.in
+--- a/.cargo/config.in
++++ b/.cargo/config.in
+@@ -7,10 +7,15 @@ git = "https://github.com/servo/serde"
+ branch = "deserialize_from_enums8"
+ replace-with = "vendored-sources"
+ 
+ [source."git+https://github.com/hsivonen/any_all_workaround?rev=7fb1b7034c9f172aade21ee1c8554e8d8a48af80"]
+ git = "https://github.com/hsivonen/any_all_workaround"
+ rev = "7fb1b7034c9f172aade21ee1c8554e8d8a48af80"
+ replace-with = "vendored-sources"
+ 
++[source."git+https://github.com/hsivonen/encoding_rs?rev=1236d1bc423e6ba35a06485f74a6304db2d703b5"]
++git = "https://github.com/hsivonen/encoding_rs"
++rev = "1236d1bc423e6ba35a06485f74a6304db2d703b5"
++replace-with = "vendored-sources"
++
+ [source.vendored-sources]
+ directory = '@top_srcdir@/third_party/rust'
+diff --git a/Cargo.lock b/Cargo.lock
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -615,21 +615,21 @@ dependencies = [
+  "encoding_rs",
+  "nserror",
+  "nsstring",
+ ]
+ 
+ [[package]]
+ name = "encoding_rs"
+ version = "0.8.35"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
++source = "git+https://github.com/hsivonen/encoding_rs?rev=1236d1bc423e6ba35a06485f74a6304db2d703b5#1236d1bc423e6ba35a06485f74a6304db2d703b5"
+ dependencies = [
+  "any_all_workaround",
+  "cfg-if 1.0.0",
++ "rustversion",
+ ]
+ 
+ [[package]]
+ name = "env_logger"
+ version = "0.5.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+ dependencies = [
+diff --git a/Cargo.toml b/Cargo.toml
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -49,8 +49,10 @@ rpath = false
+ debug-assertions = false
+ panic = "abort"
+ codegen-units = 1
+ 
+ [patch.crates-io]
+ libudev-sys = { path = "dom/webauthn/libudev-sys" }
+ serde_derive = { git = "https://github.com/servo/serde", branch = "deserialize_from_enums8" }
+ any_all_workaround = { git = "https://github.com/hsivonen/any_all_workaround", rev = "7fb1b7034c9f172aade21ee1c8554e8d8a48af80" }
++# Make --enable-rust-simd compatible with Rust 1.95
++encoding_rs = { git = "https://github.com/hsivonen/encoding_rs", rev = "1236d1bc423e6ba35a06485f74a6304db2d703b5" }
+diff --git a/third_party/rust/encoding_rs/Cargo.toml b/third_party/rust/encoding_rs/Cargo.toml
+--- a/third_party/rust/encoding_rs/Cargo.toml
++++ b/third_party/rust/encoding_rs/Cargo.toml
+@@ -11,16 +11,17 @@
+ 
+ [package]
+ edition = "2018"
+ rust-version = "1.36"
+ name = "encoding_rs"
+ version = "0.8.35"
+ authors = ["Henri Sivonen <hsivonen@hsivonen.fi>"]
+ build = false
++autolib = false
+ autobins = false
+ autoexamples = false
+ autotests = false
+ autobenches = false
+ description = "A Gecko-oriented implementation of the Encoding Standard"
+ homepage = "https://docs.rs/encoding_rs/"
+ documentation = "https://docs.rs/encoding_rs/"
+ readme = "README.md"
+@@ -34,43 +35,16 @@ categories = [
+     "text-processing",
+     "encoding",
+     "web-programming",
+     "internationalization",
+ ]
+ license = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+ repository = "https://github.com/hsivonen/encoding_rs"
+ 
+-[profile.release]
+-lto = true
+-
+-[lib]
+-name = "encoding_rs"
+-path = "src/lib.rs"
+-
+-[dependencies.any_all_workaround]
+-version = "0.1.0"
+-optional = true
+-
+-[dependencies.cfg-if]
+-version = "1.0"
+-
+-[dependencies.serde]
+-version = "1.0"
+-optional = true
+-
+-[dev-dependencies.bincode]
+-version = "1.0"
+-
+-[dev-dependencies.serde_derive]
+-version = "1.0"
+-
+-[dev-dependencies.serde_json]
+-version = "1.0"
+-
+ [features]
+ alloc = []
+ default = ["alloc"]
+ fast-big5-hanzi-encode = []
+ fast-gb-hanzi-encode = []
+ fast-hangul-encode = []
+ fast-hanja-encode = []
+ fast-kanji-encode = []
+@@ -79,9 +53,39 @@ fast-legacy-encode = [
+     "fast-hanja-encode",
+     "fast-kanji-encode",
+     "fast-gb-hanzi-encode",
+     "fast-big5-hanzi-encode",
+ ]
+ less-slow-big5-hanzi-encode = []
+ less-slow-gb-hanzi-encode = []
+ less-slow-kanji-encode = []
+-simd-accel = ["any_all_workaround"]
++simd-accel = [
++    "any_all_workaround",
++    "rustversion",
++]
++
++[lib]
++name = "encoding_rs"
++path = "src/lib.rs"
++
++[dependencies]
++cfg-if = "1.0"
++
++[dependencies.any_all_workaround]
++version = "0.1.0"
++optional = true
++
++[dependencies.rustversion]
++version = "1.0.19"
++optional = true
++
++[dependencies.serde]
++version = "1.0"
++optional = true
++
++[dev-dependencies]
++bincode = "1.0"
++serde_derive = "1.0"
++serde_json = "1.0"
++
++[profile.release]
++lto = true
+diff --git a/third_party/rust/encoding_rs/src/x_user_defined.rs b/third_party/rust/encoding_rs/src/x_user_defined.rs
+--- a/third_party/rust/encoding_rs/src/x_user_defined.rs
++++ b/third_party/rust/encoding_rs/src/x_user_defined.rs
+@@ -11,16 +11,18 @@ use super::*;
+ use crate::handles::*;
+ use crate::variant::*;
+ 
+ cfg_if! {
+     if #[cfg(feature = "simd-accel")] {
+         use simd_funcs::*;
+         use core::simd::u16x8;
+         use core::simd::cmp::SimdPartialOrd;
++        #[rustversion::since(1.95)]
++        use core::simd::Select;
+ 
+         #[inline(always)]
+         fn shift_upper(unpacked: u16x8) -> u16x8 {
+             let highest_ascii = u16x8::splat(0x7F);
+             unpacked + unpacked.simd_gt(highest_ascii).select(u16x8::splat(0xF700), u16x8::splat(0))        }
+     } else {
+     }
+ }

--- a/seamonkey/6012-add-rustversion-crate-mozbg1882209.patch
+++ b/seamonkey/6012-add-rustversion-crate-mozbg1882209.patch
@@ -1,0 +1,2276 @@
+# HG changeset patch
+# User Frank-Rainer Grahl <frgrahl@gmx.net>
+# Date 1785108032 -7200
+# Parent  9dffd78611d08034adaba702d208ea8979bd7c40
+No Bug - Add rust version crate. r=me a=me
+
+diff --git a/Cargo.lock b/Cargo.lock
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1714,16 +1714,22 @@ name = "rustc_version"
+ version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"
+ dependencies = [
+  "semver",
+ ]
+ 
+ [[package]]
++name = "rustversion"
++version = "1.0.23"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
++
++[[package]]
+ name = "same-file"
+ version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
+ dependencies = [
+  "winapi 0.3.7",
+ ]
+ 
+diff --git a/third_party/rust/encoding_rs/.cargo-checksum.json b/third_party/rust/encoding_rs/.cargo-checksum.json
+--- a/third_party/rust/encoding_rs/.cargo-checksum.json
++++ b/third_party/rust/encoding_rs/.cargo-checksum.json
+@@ -1,1 +1,1 @@
+-{"files":{"CONTRIBUTING.md":"ca1901f3e8532fb4cec894fd3664f0eaa898c0c4b961d1b992d1ed54eacf362a","COPYRIGHT":"11789f45bb180841cd362a5eee6789c68ddb573a11105e30768c308a6add0190","Cargo.toml":"d7405d2bcf99cf9729075473c45f677630f4c1947c8ba9757db607f2025a7da2","Ideas.md":"b7452893f500163868d8de52c09addaf91e1632454ed02e892c467ed7ec39dbd","LICENSE-APACHE":"cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","LICENSE-MIT":"3fa4ca83dcc9237839b1bdeb2e6d16bdfb5ec0c5ce42b24694d8bbf0dcbef72c","LICENSE-WHATWG":"838118388fe5c2e7f1dbbaeed13e1c7f3ebf88be91319c7c1d77c18e987d1a50","README.md":"9826137ed4297be3b2019b74a8f6111a796ff507bde41df2f20712539704b9e9","ci/miri.sh":"43cb8d82f49e3bfe2d2274b6ccd6f0714a4188ccef0cecc040829883cfdbee25","doc/Big5.txt":"f73a2edc5cb6c2d140ba6e07f4542e1c4a234950378acde1df93480f0ca0be0b","doc/EUC-JP.txt":"ee2818b907d0137f40a9ab9fd525fc700a44dbdddb6cf0c157a656566bae4bf1","doc/EUC-KR.txt":"71d9e2ccf3b124e8bdfb433c8cf2773fd878077038d0cec3c7237a50f4a78a30","doc/GBK.txt":"8229e59076d8bddb01865cdcf6afda3533238d7c23d97f98820f9e3b2d13505d","doc/IBM866.txt":"a5a433e804d0f83af785015179fbc1d9b0eaf1f7960efcd04093e136b51fbd0e","doc/ISO-2022-JP.txt":"af86684f5a8f0e2868d7b2c292860140c3d2e5527530ca091f1b28198e8e2fe6","doc/ISO-8859-10.txt":"6d3949ad7c81ca176895101ed81a1db7df1060d64e262880b94bd31bb344ab4d","doc/ISO-8859-13.txt":"3951dd89cf93f7729148091683cf8511f4529388b7dc8dcd0d62eaed55be93fa","doc/ISO-8859-14.txt":"3d330784a0374fd255a38b47949675cc7168c800530534b0a01cac6edc623adc","doc/ISO-8859-15.txt":"24b1084aab5127a85aab99153f86e24694d0a3615f53b5ce23683f97cf66c47a","doc/ISO-8859-16.txt":"ce0272559b92ba76d7a7e476f6424ae4a5cc72e75b183611b08392e44add4d25","doc/ISO-8859-2.txt":"18ceff88c13d1b5ba455a3919b1e3de489045c4c3d2dd7e8527c125c75d54aad","doc/ISO-8859-3.txt":"21798404c68f4f5db59223362f24999da96968c0628427321fccce7d2849a130","doc/ISO-8859-4.txt":"d27f6520c6c5bfbcc19176b71d081cdb3bccde1622bb3e420d5680e812632d53","doc/ISO-8859-5.txt":"a10ec8d6ea7a78ad15da7275f6cb1a3365118527e28f9af6d0d5830501303f3a","doc/ISO-8859-6.txt":"ccda8a2efc96115336bdd77776637b9712425e44fbcf745353b9057fbef144e7","doc/ISO-8859-7.txt":"17900fa1f27a445958f0a77d7d9056be375a6bd7ee4492aa680c7c1500bab85e","doc/ISO-8859-8-I.txt":"8357555646d54265a9b9ffa3e68b08d132312f1561c60108ff9b8b1167b6ecf2","doc/ISO-8859-8.txt":"72cd6f3afb7b4a9c16a66a362473315770b7755d72c86c870e52fc3eba86c8af","doc/KOI8-R.txt":"839cf19a38da994488004ed7814b1f6151640156a9a2af02bf2efca745fb5966","doc/KOI8-U.txt":"0cc76624ed1f024183e2298b7e019957da2c70c8ca06e0fc4e6f353f50a5054f","doc/Shift_JIS.txt":"34c49141818cb9ddbcf59cc858f78a79be8ad148d563f26415108ae1f148443f","doc/UTF-16BE.txt":"e2e280d8acbaa6d2a6b3569d60e17500a285f2baa0df3363dd85537cd5a1ef8f","doc/UTF-16LE.txt":"70bdc170e3fc5298ba68f10125fb5eeb8b077036cc96bb4416c4de396f6d76c1","doc/UTF-8.txt":"ea7bae742e613010ced002cf4b601a737d2203fad65e115611451bc4428f548a","doc/gb18030.txt":"67a01665c75505330b0fe5b8d88d5873d8ce555a145c77dca04a467fa2680744","doc/macintosh.txt":"57491e53866711b4672d9b9ff35380b9dac9e0d8e3d6c20bdd6140603687c023","doc/replacement.txt":"4b6c3bbd7999d9d4108a281594bd02d13607e334a95465afff8c2c08d395f0e4","doc/windows-1250.txt":"61296bb6a21cdab602300d32ecfba434cb82de5ac3bc88d58710d2f125e28d39","doc/windows-1251.txt":"7deea1c61dea1485c8ff02db2c7d578db7a9aab63ab1cfd02ec04b515864689e","doc/windows-1252.txt":"933ef3bdddfce5ee132b9f1a1aa8b47423d2587bbe475b19028d0a6d38e180b6","doc/windows-1253.txt":"1a38748b88e99071a5c7b3d5456ead4caedeabab50d50d658be105bc113714de","doc/windows-1254.txt":"f8372f86c6f8d642563cd6ddc025260553292a39423df1683a98670bd7bf2b47","doc/windows-1255.txt":"4e5852494730054e2da258a74e1b9d780abbcdd8ce22ebc218ca2efe9e90493d","doc/windows-1256.txt":"c0879c5172abedead302a406e8f60d9cd9598694a0ffa4fd288ffe4fef7b8ea1","doc/windows-1257.txt":"c28a0c9f964fcb2b46d21f537c402446501a2800670481d6abf9fd9e9018d523","doc/windows-1258.txt":"5019ae4d61805c79aacbf17c93793342dbb098d65a1837783bc3e2c6d6a23602","doc/windows-874.txt":"4ef0e4501c5feba8b17aee1818602ed44b36ca8475db771ce2fc16d392cabecc","doc/x-mac-cyrillic.txt":"58be154d8a888ca3d484b83b44f749823ef339ab27f14d90ca9a856f5050a8bd","doc/x-user-defined.txt":"f9cd07c4321bf5cfb0be4bdddd251072999b04a6cf7a6f5bc63709a84e2c1ffc","generate-encoding-data.py":"6f34a845785f53425accf30759edc566873fcb0c2188648e07b09c898f39dddb","rustfmt.toml":"85c1a3b4382fd89e991cbb81b70fb52780472edc064c963943cdaaa56e0a2030","src/ascii.rs":"588e38b01e666d5e7462617ea7e90a108d608dec9e016f3d273ac0744af2e05d","src/big5.rs":"ec6e2913011a38e9a3e825a1731f139a7ca1d5b264fefae51a3cc1a68a57cef9","src/data.rs":"b93f34025fe5c6a85b4b9f0037bf58961352bf19c83f91b09b35eb8495625eec","src/euc_jp.rs":"32047f5b540188c4cb19c07165f846b9786a09f18e315ed3e9bda1293dae52aa","src/euc_kr.rs":"9b25afc72d9378700eecfac58d55ad1c5946d6cd0ccde2c29c08200ef2de6bb9","src/gb18030.rs":"89cd6ae2247add3f3471a699bc12113a9ae2f6b91a5223abbf15b68a13537dcd","src/gb18030_2022.rs":"3c2e06492c5e00fcd39515e4af4c560d8cee5c31e7a7e388db682bc9ee33ee32","src/handles.rs":"b08cef1f5785bb6a4822f2e844c6df1b046b737b7a075e4593eaa8c4208e9fe2","src/iso_2022_jp.rs":"9bb485e82574f4b7d4b2364f0ff276acb6a0bc111758420a3b0ec5e04c196652","src/lib.rs":"c4d9fa1c43105e2310122f1b9197125032e607fe6f79bc22769b340de76e2430","src/macros.rs":"200997f8870de8bfd8cdc475e92115df42108c0df661e49d3d1cbc32056e1d99","src/mem.rs":"948571137d3b151df8db4fb2c733e74ae595d055cdf0ad83abcab9341d6adabe","src/replacement.rs":"7660b34a53f8c1ca2bdfa0e51e843ec28326950952ad8bc96569feb93ac62308","src/shift_jis.rs":"6951ae67e36b1a12fa3a30734957f444d8b1b4ae0e2bde52060b29bd0f16d9d9","src/simd_funcs.rs":"05c6e77af74bfe73cd39a752067c11425d6b46e5da419910f54bf75a5c02a984","src/single_byte.rs":"3ad87116fb339434a4b58e8f2b15485f2b66b9f7814d708f16194ed08f6d6ccf","src/test_data/big5_in.txt":"a5ae290786610c7facdbb1d06be6815e8bb81d68dfa7380edc7ddb6b8c7e412e","src/test_data/big5_in_ref.txt":"52733d9970fb8987f014fa0eac2792250123cf583b363beb2ce7b3c55e3dc555","src/test_data/big5_out.txt":"57420ca41a669c949738c84cab620020959572d2ee97b4e059405bfe26a79b6d","src/test_data/big5_out_ref.txt":"00e5f67c222dd5cd3bb1739276910b8f0032f454cba7cf7c3eaa255a564188d0","src/test_data/euc_kr_in.txt":"21534ec87e82d785d128f980902d13fab6d9dea15c69a991f409d9b0afd1c852","src/test_data/euc_kr_in_ref.txt":"b3009e6a94967df1f1135c66f005610bebad6666d634aec72d2ad77c3211bda3","src/test_data/euc_kr_out.txt":"20205b0b5be4f579271193b5bfbc549a61a9fd5217c33eecfa61784a3ffe2e9d","src/test_data/euc_kr_out_ref.txt":"b5f566237f8d4ef4d03ad26135ca97dfd7398608a82165bd4853b5134ab22cb5","src/test_data/gb18030_in.txt":"0dd1fbf0360930daafdce7e6761852005a8f92f7910180df19a070b6c3c59dee","src/test_data/gb18030_in_ref.txt":"f3eaea1115857054cf30f8ba18219e72377f2a4afd848ccf223770d75aa4251d","src/test_data/gb18030_out.txt":"7184fe9592609597d55c2733606b4c4b1a18b79b24533e1a16a14ff92e7d2b55","src/test_data/gb18030_out_ref.txt":"23bb850ddc69aaf1bdfeabe05a12d93f614e5560dac879d5f02929ee4a7c06c5","src/test_data/iso_2022_jp_in.txt":"98fb823530a30a76eb0ba7ab6ac796959e8869c1ec143f018a1964581ae813aa","src/test_data/iso_2022_jp_in_ref.txt":"df82166d2e01bb446211d7e46f33b47d93ac1bafeae2ed880ee93c4096d11210","src/test_data/iso_2022_jp_out.txt":"bef8eb4804ed0843b9dffdd1d168738635cc77f8d0929beb2532b686318ddae6","src/test_data/iso_2022_jp_out_ref.txt":"b221b36b2bce49d49b620dc8ba80d77bac74e8660a86a11628e79b67f1d98964","src/test_data/jis0208_in.txt":"3c1a7aaada00d6fff41e60bd7589d7ae94afaf562759b116958b1d84711d17b6","src/test_data/jis0208_in_ref.txt":"df82166d2e01bb446211d7e46f33b47d93ac1bafeae2ed880ee93c4096d11210","src/test_data/jis0208_out.txt":"a6188b67eb00ba980cb83056186c89bcdddc1b0210af9afa78ed1c9b7a098950","src/test_data/jis0208_out_ref.txt":"e75a986fe5e78e64bf8fafd7392ae96ee0cb0a4b2e7ef2fe722b3caacf3e2f70","src/test_data/jis0212_in.txt":"9eda766002646a27310457c661832429beff9089d2703355812c4cac30d800b5","src/test_data/jis0212_in_ref.txt":"fcf74c58d2cbe9b3f3db4fa9eff26e09f5e9644097c78614c03177e938988d03","src/test_data/shift_jis_in.txt":"e65df746be90359e70422868522a7aa3e8ed20e0d4c0cf9995d9de248bf93388","src/test_data/shift_jis_in_ref.txt":"13b15aed64e9e7cb35e6a740b67413f0c285fda944f4814d45a7619ea338fb5e","src/test_data/shift_jis_out.txt":"192d0a4a8ce5d0f904c5cb283dfb974577ee667cf1e71955a6dd6aece2b354ef","src/test_data/shift_jis_out_ref.txt":"cb6d50b0c11bad1d1f1fcc02d779672a8b9a2509cbbafdc6392aceb49c8b4268","src/test_labels_names.rs":"23a2e11b02b3b8d15fb5613a625e3edb2c61e70e3c581abfd638719a4088200d","src/testing.rs":"f59e671e95a98a56f6b573e8c6be4d71e670bf52f7e20eb1605d990aafa1894e","src/utf_16.rs":"c071a147fad38d750c2c247e141b76b929a48007b99f26b2922b9caecdaf2f25","src/utf_8.rs":"7b7d887b347f1aefa03246b028a36a72758a4ce76c28f3b45c19467851aa7839","src/variant.rs":"1fab5363588a1554a7169de8731ea9cded7ac63ea35caabdd1c27a8dde68c27b","src/x_user_defined.rs":"9456ca46168ef86c98399a2536f577ef7be3cdde90c0c51392d8ac48519d3fae"},"package":"75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"}
+\ No newline at end of file
++{"files":{"CONTRIBUTING.md":"ca1901f3e8532fb4cec894fd3664f0eaa898c0c4b961d1b992d1ed54eacf362a","COPYRIGHT":"11789f45bb180841cd362a5eee6789c68ddb573a11105e30768c308a6add0190","Cargo.toml":"bfec06bc62932b629faa578d5fefbc4dc8ddbd6c807e542f6a676dc283e2f716","Ideas.md":"b7452893f500163868d8de52c09addaf91e1632454ed02e892c467ed7ec39dbd","LICENSE-APACHE":"cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","LICENSE-MIT":"3fa4ca83dcc9237839b1bdeb2e6d16bdfb5ec0c5ce42b24694d8bbf0dcbef72c","LICENSE-WHATWG":"838118388fe5c2e7f1dbbaeed13e1c7f3ebf88be91319c7c1d77c18e987d1a50","README.md":"9826137ed4297be3b2019b74a8f6111a796ff507bde41df2f20712539704b9e9","ci/miri.sh":"43cb8d82f49e3bfe2d2274b6ccd6f0714a4188ccef0cecc040829883cfdbee25","doc/Big5.txt":"f73a2edc5cb6c2d140ba6e07f4542e1c4a234950378acde1df93480f0ca0be0b","doc/EUC-JP.txt":"ee2818b907d0137f40a9ab9fd525fc700a44dbdddb6cf0c157a656566bae4bf1","doc/EUC-KR.txt":"71d9e2ccf3b124e8bdfb433c8cf2773fd878077038d0cec3c7237a50f4a78a30","doc/GBK.txt":"8229e59076d8bddb01865cdcf6afda3533238d7c23d97f98820f9e3b2d13505d","doc/IBM866.txt":"a5a433e804d0f83af785015179fbc1d9b0eaf1f7960efcd04093e136b51fbd0e","doc/ISO-2022-JP.txt":"af86684f5a8f0e2868d7b2c292860140c3d2e5527530ca091f1b28198e8e2fe6","doc/ISO-8859-10.txt":"6d3949ad7c81ca176895101ed81a1db7df1060d64e262880b94bd31bb344ab4d","doc/ISO-8859-13.txt":"3951dd89cf93f7729148091683cf8511f4529388b7dc8dcd0d62eaed55be93fa","doc/ISO-8859-14.txt":"3d330784a0374fd255a38b47949675cc7168c800530534b0a01cac6edc623adc","doc/ISO-8859-15.txt":"24b1084aab5127a85aab99153f86e24694d0a3615f53b5ce23683f97cf66c47a","doc/ISO-8859-16.txt":"ce0272559b92ba76d7a7e476f6424ae4a5cc72e75b183611b08392e44add4d25","doc/ISO-8859-2.txt":"18ceff88c13d1b5ba455a3919b1e3de489045c4c3d2dd7e8527c125c75d54aad","doc/ISO-8859-3.txt":"21798404c68f4f5db59223362f24999da96968c0628427321fccce7d2849a130","doc/ISO-8859-4.txt":"d27f6520c6c5bfbcc19176b71d081cdb3bccde1622bb3e420d5680e812632d53","doc/ISO-8859-5.txt":"a10ec8d6ea7a78ad15da7275f6cb1a3365118527e28f9af6d0d5830501303f3a","doc/ISO-8859-6.txt":"ccda8a2efc96115336bdd77776637b9712425e44fbcf745353b9057fbef144e7","doc/ISO-8859-7.txt":"17900fa1f27a445958f0a77d7d9056be375a6bd7ee4492aa680c7c1500bab85e","doc/ISO-8859-8-I.txt":"8357555646d54265a9b9ffa3e68b08d132312f1561c60108ff9b8b1167b6ecf2","doc/ISO-8859-8.txt":"72cd6f3afb7b4a9c16a66a362473315770b7755d72c86c870e52fc3eba86c8af","doc/KOI8-R.txt":"839cf19a38da994488004ed7814b1f6151640156a9a2af02bf2efca745fb5966","doc/KOI8-U.txt":"0cc76624ed1f024183e2298b7e019957da2c70c8ca06e0fc4e6f353f50a5054f","doc/Shift_JIS.txt":"34c49141818cb9ddbcf59cc858f78a79be8ad148d563f26415108ae1f148443f","doc/UTF-16BE.txt":"e2e280d8acbaa6d2a6b3569d60e17500a285f2baa0df3363dd85537cd5a1ef8f","doc/UTF-16LE.txt":"70bdc170e3fc5298ba68f10125fb5eeb8b077036cc96bb4416c4de396f6d76c1","doc/UTF-8.txt":"ea7bae742e613010ced002cf4b601a737d2203fad65e115611451bc4428f548a","doc/gb18030.txt":"67a01665c75505330b0fe5b8d88d5873d8ce555a145c77dca04a467fa2680744","doc/macintosh.txt":"57491e53866711b4672d9b9ff35380b9dac9e0d8e3d6c20bdd6140603687c023","doc/replacement.txt":"4b6c3bbd7999d9d4108a281594bd02d13607e334a95465afff8c2c08d395f0e4","doc/windows-1250.txt":"61296bb6a21cdab602300d32ecfba434cb82de5ac3bc88d58710d2f125e28d39","doc/windows-1251.txt":"7deea1c61dea1485c8ff02db2c7d578db7a9aab63ab1cfd02ec04b515864689e","doc/windows-1252.txt":"933ef3bdddfce5ee132b9f1a1aa8b47423d2587bbe475b19028d0a6d38e180b6","doc/windows-1253.txt":"1a38748b88e99071a5c7b3d5456ead4caedeabab50d50d658be105bc113714de","doc/windows-1254.txt":"f8372f86c6f8d642563cd6ddc025260553292a39423df1683a98670bd7bf2b47","doc/windows-1255.txt":"4e5852494730054e2da258a74e1b9d780abbcdd8ce22ebc218ca2efe9e90493d","doc/windows-1256.txt":"c0879c5172abedead302a406e8f60d9cd9598694a0ffa4fd288ffe4fef7b8ea1","doc/windows-1257.txt":"c28a0c9f964fcb2b46d21f537c402446501a2800670481d6abf9fd9e9018d523","doc/windows-1258.txt":"5019ae4d61805c79aacbf17c93793342dbb098d65a1837783bc3e2c6d6a23602","doc/windows-874.txt":"4ef0e4501c5feba8b17aee1818602ed44b36ca8475db771ce2fc16d392cabecc","doc/x-mac-cyrillic.txt":"58be154d8a888ca3d484b83b44f749823ef339ab27f14d90ca9a856f5050a8bd","doc/x-user-defined.txt":"f9cd07c4321bf5cfb0be4bdddd251072999b04a6cf7a6f5bc63709a84e2c1ffc","generate-encoding-data.py":"6f34a845785f53425accf30759edc566873fcb0c2188648e07b09c898f39dddb","rustfmt.toml":"85c1a3b4382fd89e991cbb81b70fb52780472edc064c963943cdaaa56e0a2030","src/ascii.rs":"588e38b01e666d5e7462617ea7e90a108d608dec9e016f3d273ac0744af2e05d","src/big5.rs":"ec6e2913011a38e9a3e825a1731f139a7ca1d5b264fefae51a3cc1a68a57cef9","src/data.rs":"b93f34025fe5c6a85b4b9f0037bf58961352bf19c83f91b09b35eb8495625eec","src/euc_jp.rs":"32047f5b540188c4cb19c07165f846b9786a09f18e315ed3e9bda1293dae52aa","src/euc_kr.rs":"9b25afc72d9378700eecfac58d55ad1c5946d6cd0ccde2c29c08200ef2de6bb9","src/gb18030.rs":"89cd6ae2247add3f3471a699bc12113a9ae2f6b91a5223abbf15b68a13537dcd","src/gb18030_2022.rs":"3c2e06492c5e00fcd39515e4af4c560d8cee5c31e7a7e388db682bc9ee33ee32","src/handles.rs":"b08cef1f5785bb6a4822f2e844c6df1b046b737b7a075e4593eaa8c4208e9fe2","src/iso_2022_jp.rs":"9bb485e82574f4b7d4b2364f0ff276acb6a0bc111758420a3b0ec5e04c196652","src/lib.rs":"c4d9fa1c43105e2310122f1b9197125032e607fe6f79bc22769b340de76e2430","src/macros.rs":"200997f8870de8bfd8cdc475e92115df42108c0df661e49d3d1cbc32056e1d99","src/mem.rs":"948571137d3b151df8db4fb2c733e74ae595d055cdf0ad83abcab9341d6adabe","src/replacement.rs":"7660b34a53f8c1ca2bdfa0e51e843ec28326950952ad8bc96569feb93ac62308","src/shift_jis.rs":"6951ae67e36b1a12fa3a30734957f444d8b1b4ae0e2bde52060b29bd0f16d9d9","src/simd_funcs.rs":"05c6e77af74bfe73cd39a752067c11425d6b46e5da419910f54bf75a5c02a984","src/single_byte.rs":"3ad87116fb339434a4b58e8f2b15485f2b66b9f7814d708f16194ed08f6d6ccf","src/test_data/big5_in.txt":"a5ae290786610c7facdbb1d06be6815e8bb81d68dfa7380edc7ddb6b8c7e412e","src/test_data/big5_in_ref.txt":"52733d9970fb8987f014fa0eac2792250123cf583b363beb2ce7b3c55e3dc555","src/test_data/big5_out.txt":"57420ca41a669c949738c84cab620020959572d2ee97b4e059405bfe26a79b6d","src/test_data/big5_out_ref.txt":"00e5f67c222dd5cd3bb1739276910b8f0032f454cba7cf7c3eaa255a564188d0","src/test_data/euc_kr_in.txt":"21534ec87e82d785d128f980902d13fab6d9dea15c69a991f409d9b0afd1c852","src/test_data/euc_kr_in_ref.txt":"b3009e6a94967df1f1135c66f005610bebad6666d634aec72d2ad77c3211bda3","src/test_data/euc_kr_out.txt":"20205b0b5be4f579271193b5bfbc549a61a9fd5217c33eecfa61784a3ffe2e9d","src/test_data/euc_kr_out_ref.txt":"b5f566237f8d4ef4d03ad26135ca97dfd7398608a82165bd4853b5134ab22cb5","src/test_data/gb18030_in.txt":"0dd1fbf0360930daafdce7e6761852005a8f92f7910180df19a070b6c3c59dee","src/test_data/gb18030_in_ref.txt":"f3eaea1115857054cf30f8ba18219e72377f2a4afd848ccf223770d75aa4251d","src/test_data/gb18030_out.txt":"7184fe9592609597d55c2733606b4c4b1a18b79b24533e1a16a14ff92e7d2b55","src/test_data/gb18030_out_ref.txt":"23bb850ddc69aaf1bdfeabe05a12d93f614e5560dac879d5f02929ee4a7c06c5","src/test_data/iso_2022_jp_in.txt":"98fb823530a30a76eb0ba7ab6ac796959e8869c1ec143f018a1964581ae813aa","src/test_data/iso_2022_jp_in_ref.txt":"df82166d2e01bb446211d7e46f33b47d93ac1bafeae2ed880ee93c4096d11210","src/test_data/iso_2022_jp_out.txt":"bef8eb4804ed0843b9dffdd1d168738635cc77f8d0929beb2532b686318ddae6","src/test_data/iso_2022_jp_out_ref.txt":"b221b36b2bce49d49b620dc8ba80d77bac74e8660a86a11628e79b67f1d98964","src/test_data/jis0208_in.txt":"3c1a7aaada00d6fff41e60bd7589d7ae94afaf562759b116958b1d84711d17b6","src/test_data/jis0208_in_ref.txt":"df82166d2e01bb446211d7e46f33b47d93ac1bafeae2ed880ee93c4096d11210","src/test_data/jis0208_out.txt":"a6188b67eb00ba980cb83056186c89bcdddc1b0210af9afa78ed1c9b7a098950","src/test_data/jis0208_out_ref.txt":"e75a986fe5e78e64bf8fafd7392ae96ee0cb0a4b2e7ef2fe722b3caacf3e2f70","src/test_data/jis0212_in.txt":"9eda766002646a27310457c661832429beff9089d2703355812c4cac30d800b5","src/test_data/jis0212_in_ref.txt":"fcf74c58d2cbe9b3f3db4fa9eff26e09f5e9644097c78614c03177e938988d03","src/test_data/shift_jis_in.txt":"e65df746be90359e70422868522a7aa3e8ed20e0d4c0cf9995d9de248bf93388","src/test_data/shift_jis_in_ref.txt":"13b15aed64e9e7cb35e6a740b67413f0c285fda944f4814d45a7619ea338fb5e","src/test_data/shift_jis_out.txt":"192d0a4a8ce5d0f904c5cb283dfb974577ee667cf1e71955a6dd6aece2b354ef","src/test_data/shift_jis_out_ref.txt":"cb6d50b0c11bad1d1f1fcc02d779672a8b9a2509cbbafdc6392aceb49c8b4268","src/test_labels_names.rs":"23a2e11b02b3b8d15fb5613a625e3edb2c61e70e3c581abfd638719a4088200d","src/testing.rs":"f59e671e95a98a56f6b573e8c6be4d71e670bf52f7e20eb1605d990aafa1894e","src/utf_16.rs":"c071a147fad38d750c2c247e141b76b929a48007b99f26b2922b9caecdaf2f25","src/utf_8.rs":"7b7d887b347f1aefa03246b028a36a72758a4ce76c28f3b45c19467851aa7839","src/variant.rs":"1fab5363588a1554a7169de8731ea9cded7ac63ea35caabdd1c27a8dde68c27b","src/x_user_defined.rs":"d733660c7775afa8007cfc80c09057d875d6613aaf98c7dc942e47fb93306feb"},"package":null}
+\ No newline at end of file
+diff --git a/third_party/rust/encoding_rs/Cargo.toml b/third_party/rust/encoding_rs/Cargo.toml
+--- a/third_party/rust/encoding_rs/Cargo.toml
++++ b/third_party/rust/encoding_rs/Cargo.toml
+@@ -10,22 +10,16 @@
+ # See Cargo.toml.orig for the original contents.
+ 
+ [package]
+ edition = "2018"
+ rust-version = "1.36"
+ name = "encoding_rs"
+ version = "0.8.35"
+ authors = ["Henri Sivonen <hsivonen@hsivonen.fi>"]
+-build = false
+-autolib = false
+-autobins = false
+-autoexamples = false
+-autotests = false
+-autobenches = false
+ description = "A Gecko-oriented implementation of the Encoding Standard"
+ homepage = "https://docs.rs/encoding_rs/"
+ documentation = "https://docs.rs/encoding_rs/"
+ readme = "README.md"
+ keywords = [
+     "encoding",
+     "web",
+     "unicode",
+@@ -35,16 +29,39 @@ categories = [
+     "text-processing",
+     "encoding",
+     "web-programming",
+     "internationalization",
+ ]
+ license = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+ repository = "https://github.com/hsivonen/encoding_rs"
+ 
++[profile.release]
++lto = true
++
++[dependencies]
++cfg-if = "1.0"
++
++[dependencies.any_all_workaround]
++version = "0.1.0"
++optional = true
++
++[dependencies.rustversion]
++version = "1.0.19"
++optional = true
++
++[dependencies.serde]
++version = "1.0"
++optional = true
++
++[dev-dependencies]
++bincode = "1.0"
++serde_derive = "1.0"
++serde_json = "1.0"
++
+ [features]
+ alloc = []
+ default = ["alloc"]
+ fast-big5-hanzi-encode = []
+ fast-gb-hanzi-encode = []
+ fast-hangul-encode = []
+ fast-hanja-encode = []
+ fast-kanji-encode = []
+@@ -57,35 +74,8 @@ fast-legacy-encode = [
+ ]
+ less-slow-big5-hanzi-encode = []
+ less-slow-gb-hanzi-encode = []
+ less-slow-kanji-encode = []
+ simd-accel = [
+     "any_all_workaround",
+     "rustversion",
+ ]
+-
+-[lib]
+-name = "encoding_rs"
+-path = "src/lib.rs"
+-
+-[dependencies]
+-cfg-if = "1.0"
+-
+-[dependencies.any_all_workaround]
+-version = "0.1.0"
+-optional = true
+-
+-[dependencies.rustversion]
+-version = "1.0.19"
+-optional = true
+-
+-[dependencies.serde]
+-version = "1.0"
+-optional = true
+-
+-[dev-dependencies]
+-bincode = "1.0"
+-serde_derive = "1.0"
+-serde_json = "1.0"
+-
+-[profile.release]
+-lto = true
+diff --git a/third_party/rust/rustversion/.cargo-checksum.json b/third_party/rust/rustversion/.cargo-checksum.json
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/.cargo-checksum.json
+@@ -0,0 +1,1 @@
++{"files":{"Cargo.toml":"fc211ccd64d3ad59a0715c1a6f8cbfbbd83045f644194394595d16646eee9947","LICENSE-APACHE":"62c7a1e35f56406896d7aa7ca52d0cc0d272ac022b5d2796e7d6905db8a3636a","LICENSE-MIT":"23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3","README.md":"913d04d158843566991845cc9d76e24610bf31f5a99e55115023ccc0b16ff1e7","build/build.rs":"4438b108d5b198ca43ef0a78509da89861020674abd05166addd1c3058afbfa6","build/rustc.rs":"faf67033ec831d968406f5a66c475df337f7221e9d1ab3477fed3a629e1ec5bc","src/attr.rs":"9301cd4aff5a9648c057d5d8de9eb66921f0c3a715c51ada4459576bd49c8b19","src/bound.rs":"13c35302bd5d96ebe54509477e736a8b720e18cb2474e5805480c4517a20e5b0","src/constfn.rs":"613b8f53b21cc06b4f619fce9000993d3e7873b650701ca01cef1e53bed5b40a","src/date.rs":"f79c55ddcd18e124610cd5c9867b1ebaae1feeb6dfc37e2b7f94e3137aa883b6","src/error.rs":"cb37102f03ebbaca313d80f9714fe08dfef92fe956789ee87d93eb6121705f4f","src/expand.rs":"9c93525a8c4a0e620369ed256a1ee40a0b48f984e0fad8db8c0e2998bc8ecb23","src/expr.rs":"8e8ca76f4f5838436d9d7273f499c698bb41f6c15bc07d32ec5c1cb8bd3dd731","src/iter.rs":"8d4b817b9abc4e817105b673e15f29ef9bb8284a010ce01ac2d83387fe136947","src/lib.rs":"77c732493550b7e7a46ae2d25e89c363a851ba25a9e9a89f1aad67bad4afbb04","src/release.rs":"e0755ed1889b4c6f0faaa5adee5f60f27f9926becff875dbb41b6a65ae756591","src/time.rs":"6fcf3a1ed238a97bd7a39b187c88bdcef0246878424e06aa7eb779f841529b34","src/token.rs":"824ce765f692db73afa02d3ebb0281c750748035efc98fa547be29d3072665ce","src/version.rs":"afdb048bba95bbb885945eba5527b6bf0eca0105642bfc304c2f82a8b7d556df","tests/compiletest.rs":"4e381aa8ca3eabb7ac14d1e0c3700b3223e47640547a6988cfa13ad68255f60f","tests/test_const.rs":"cb1e01479bd579b1b77312a9063ab456fe44abad2243e81873c2bf7ef5f205eb","tests/test_eval.rs":"6f0ee3f49c9a0d0c374a4d0e9a9dce753cd9fc2ca7725e000a435dbd5f4a9ce3","tests/test_parse.rs":"f450e0a7f2391561484abb1b851124b5747755b76f945e121370adc710f2099d","tests/ui/bad-bound.rs":"25bde278fcaabf62868417148a5e5f2006bf589d7ebd7bf6004fb8d78e47594f","tests/ui/bad-bound.stderr":"23b4ca0aa1a7df75b5fb34e553a31faa6a3ccc029ecd7d68b056897c2c9cff9f","tests/ui/bad-date.rs":"6e23714dae8b6346fefe50dacd4abba3265248bbadfdd60c739138aa8a0037ba","tests/ui/bad-date.stderr":"f4aec72ca91ba743cadcdaf5a874c701949add5efce490aaf2bf1248ef578768","tests/ui/bad-not.rs":"f003df8bd245e9dd8edc3a6d94078ee5162fac7a98db881271f0f5b6db98d45d","tests/ui/bad-not.stderr":"1aebb3121d067d432a32dd95ff380ceac15a0531c34f90cee950582558841c56","tests/ui/bad-version.rs":"f4ea2cd038e6c63deb9c2e3ceffce93dbf179d9ce18c16d88f3b6cd7138a8c8e","tests/ui/bad-version.stderr":"e9421586d59cb9135123bd97710655014f95cc5f55b0f9611e1d2e8ce9e29a5d","tests/ui/const-not-fn.rs":"10bbe38f0d89391fff0698756e4cfd4e72a41090360393a0c951b67df14d1c35","tests/ui/const-not-fn.stderr":"1180662fd3b8c4426d46923918a2e58dd9b6259f1a364469ae13d5fc3d69ce6c"},"package":"cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"}
+\ No newline at end of file
+diff --git a/third_party/rust/rustversion/Cargo.toml b/third_party/rust/rustversion/Cargo.toml
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/Cargo.toml
+@@ -0,0 +1,69 @@
++# THIS FILE IS AUTOMATICALLY GENERATED BY CARGO
++#
++# When uploading crates to the registry Cargo will automatically
++# "normalize" Cargo.toml files for maximal compatibility
++# with all versions of Cargo and also rewrite `path` dependencies
++# to registry (e.g., crates.io) dependencies.
++#
++# If you are reading this file be aware that the original Cargo.toml
++# will likely look very different (and much more reasonable).
++# See Cargo.toml.orig for the original contents.
++
++[package]
++edition = "2018"
++rust-version = "1.31"
++name = "rustversion"
++version = "1.0.23"
++authors = ["David Tolnay <dtolnay@gmail.com>"]
++build = "build/build.rs"
++autolib = false
++autobins = false
++autoexamples = false
++autotests = false
++autobenches = false
++description = "Conditional compilation according to rustc compiler version"
++documentation = "https://docs.rs/rustversion"
++readme = "README.md"
++categories = [
++    "development-tools::build-utils",
++    "no-std",
++    "no-std::no-alloc",
++]
++license = "MIT OR Apache-2.0"
++repository = "https://github.com/dtolnay/rustversion"
++
++[package.metadata.docs.rs]
++targets = ["x86_64-unknown-linux-gnu"]
++rustdoc-args = [
++    "--generate-link-to-definition",
++    "--generate-macro-expansion",
++    "--extern-html-root-url=core=https://doc.rust-lang.org",
++    "--extern-html-root-url=alloc=https://doc.rust-lang.org",
++    "--extern-html-root-url=std=https://doc.rust-lang.org",
++    "--extern-html-root-url=proc_macro=https://doc.rust-lang.org",
++]
++
++[lib]
++name = "rustversion"
++path = "src/lib.rs"
++proc-macro = true
++
++[[test]]
++name = "compiletest"
++path = "tests/compiletest.rs"
++
++[[test]]
++name = "test_const"
++path = "tests/test_const.rs"
++
++[[test]]
++name = "test_eval"
++path = "tests/test_eval.rs"
++
++[[test]]
++name = "test_parse"
++path = "tests/test_parse.rs"
++
++[dev-dependencies.trybuild]
++version = "1.0.49"
++features = ["diff"]
+diff --git a/third_party/rust/rustversion/LICENSE-APACHE b/third_party/rust/rustversion/LICENSE-APACHE
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/LICENSE-APACHE
+@@ -0,0 +1,176 @@
++                              Apache License
++                        Version 2.0, January 2004
++                     http://www.apache.org/licenses/
++
++TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
++
++1. Definitions.
++
++   "License" shall mean the terms and conditions for use, reproduction,
++   and distribution as defined by Sections 1 through 9 of this document.
++
++   "Licensor" shall mean the copyright owner or entity authorized by
++   the copyright owner that is granting the License.
++
++   "Legal Entity" shall mean the union of the acting entity and all
++   other entities that control, are controlled by, or are under common
++   control with that entity. For the purposes of this definition,
++   "control" means (i) the power, direct or indirect, to cause the
++   direction or management of such entity, whether by contract or
++   otherwise, or (ii) ownership of fifty percent (50%) or more of the
++   outstanding shares, or (iii) beneficial ownership of such entity.
++
++   "You" (or "Your") shall mean an individual or Legal Entity
++   exercising permissions granted by this License.
++
++   "Source" form shall mean the preferred form for making modifications,
++   including but not limited to software source code, documentation
++   source, and configuration files.
++
++   "Object" form shall mean any form resulting from mechanical
++   transformation or translation of a Source form, including but
++   not limited to compiled object code, generated documentation,
++   and conversions to other media types.
++
++   "Work" shall mean the work of authorship, whether in Source or
++   Object form, made available under the License, as indicated by a
++   copyright notice that is included in or attached to the work
++   (an example is provided in the Appendix below).
++
++   "Derivative Works" shall mean any work, whether in Source or Object
++   form, that is based on (or derived from) the Work and for which the
++   editorial revisions, annotations, elaborations, or other modifications
++   represent, as a whole, an original work of authorship. For the purposes
++   of this License, Derivative Works shall not include works that remain
++   separable from, or merely link (or bind by name) to the interfaces of,
++   the Work and Derivative Works thereof.
++
++   "Contribution" shall mean any work of authorship, including
++   the original version of the Work and any modifications or additions
++   to that Work or Derivative Works thereof, that is intentionally
++   submitted to Licensor for inclusion in the Work by the copyright owner
++   or by an individual or Legal Entity authorized to submit on behalf of
++   the copyright owner. For the purposes of this definition, "submitted"
++   means any form of electronic, verbal, or written communication sent
++   to the Licensor or its representatives, including but not limited to
++   communication on electronic mailing lists, source code control systems,
++   and issue tracking systems that are managed by, or on behalf of, the
++   Licensor for the purpose of discussing and improving the Work, but
++   excluding communication that is conspicuously marked or otherwise
++   designated in writing by the copyright owner as "Not a Contribution."
++
++   "Contributor" shall mean Licensor and any individual or Legal Entity
++   on behalf of whom a Contribution has been received by Licensor and
++   subsequently incorporated within the Work.
++
++2. Grant of Copyright License. Subject to the terms and conditions of
++   this License, each Contributor hereby grants to You a perpetual,
++   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
++   copyright license to reproduce, prepare Derivative Works of,
++   publicly display, publicly perform, sublicense, and distribute the
++   Work and such Derivative Works in Source or Object form.
++
++3. Grant of Patent License. Subject to the terms and conditions of
++   this License, each Contributor hereby grants to You a perpetual,
++   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
++   (except as stated in this section) patent license to make, have made,
++   use, offer to sell, sell, import, and otherwise transfer the Work,
++   where such license applies only to those patent claims licensable
++   by such Contributor that are necessarily infringed by their
++   Contribution(s) alone or by combination of their Contribution(s)
++   with the Work to which such Contribution(s) was submitted. If You
++   institute patent litigation against any entity (including a
++   cross-claim or counterclaim in a lawsuit) alleging that the Work
++   or a Contribution incorporated within the Work constitutes direct
++   or contributory patent infringement, then any patent licenses
++   granted to You under this License for that Work shall terminate
++   as of the date such litigation is filed.
++
++4. Redistribution. You may reproduce and distribute copies of the
++   Work or Derivative Works thereof in any medium, with or without
++   modifications, and in Source or Object form, provided that You
++   meet the following conditions:
++
++   (a) You must give any other recipients of the Work or
++       Derivative Works a copy of this License; and
++
++   (b) You must cause any modified files to carry prominent notices
++       stating that You changed the files; and
++
++   (c) You must retain, in the Source form of any Derivative Works
++       that You distribute, all copyright, patent, trademark, and
++       attribution notices from the Source form of the Work,
++       excluding those notices that do not pertain to any part of
++       the Derivative Works; and
++
++   (d) If the Work includes a "NOTICE" text file as part of its
++       distribution, then any Derivative Works that You distribute must
++       include a readable copy of the attribution notices contained
++       within such NOTICE file, excluding those notices that do not
++       pertain to any part of the Derivative Works, in at least one
++       of the following places: within a NOTICE text file distributed
++       as part of the Derivative Works; within the Source form or
++       documentation, if provided along with the Derivative Works; or,
++       within a display generated by the Derivative Works, if and
++       wherever such third-party notices normally appear. The contents
++       of the NOTICE file are for informational purposes only and
++       do not modify the License. You may add Your own attribution
++       notices within Derivative Works that You distribute, alongside
++       or as an addendum to the NOTICE text from the Work, provided
++       that such additional attribution notices cannot be construed
++       as modifying the License.
++
++   You may add Your own copyright statement to Your modifications and
++   may provide additional or different license terms and conditions
++   for use, reproduction, or distribution of Your modifications, or
++   for any such Derivative Works as a whole, provided Your use,
++   reproduction, and distribution of the Work otherwise complies with
++   the conditions stated in this License.
++
++5. Submission of Contributions. Unless You explicitly state otherwise,
++   any Contribution intentionally submitted for inclusion in the Work
++   by You to the Licensor shall be under the terms and conditions of
++   this License, without any additional terms or conditions.
++   Notwithstanding the above, nothing herein shall supersede or modify
++   the terms of any separate license agreement you may have executed
++   with Licensor regarding such Contributions.
++
++6. Trademarks. This License does not grant permission to use the trade
++   names, trademarks, service marks, or product names of the Licensor,
++   except as required for reasonable and customary use in describing the
++   origin of the Work and reproducing the content of the NOTICE file.
++
++7. Disclaimer of Warranty. Unless required by applicable law or
++   agreed to in writing, Licensor provides the Work (and each
++   Contributor provides its Contributions) on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
++   implied, including, without limitation, any warranties or conditions
++   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
++   PARTICULAR PURPOSE. You are solely responsible for determining the
++   appropriateness of using or redistributing the Work and assume any
++   risks associated with Your exercise of permissions under this License.
++
++8. Limitation of Liability. In no event and under no legal theory,
++   whether in tort (including negligence), contract, or otherwise,
++   unless required by applicable law (such as deliberate and grossly
++   negligent acts) or agreed to in writing, shall any Contributor be
++   liable to You for damages, including any direct, indirect, special,
++   incidental, or consequential damages of any character arising as a
++   result of this License or out of the use or inability to use the
++   Work (including but not limited to damages for loss of goodwill,
++   work stoppage, computer failure or malfunction, or any and all
++   other commercial damages or losses), even if such Contributor
++   has been advised of the possibility of such damages.
++
++9. Accepting Warranty or Additional Liability. While redistributing
++   the Work or Derivative Works thereof, You may choose to offer,
++   and charge a fee for, acceptance of support, warranty, indemnity,
++   or other liability obligations and/or rights consistent with this
++   License. However, in accepting such obligations, You may act only
++   on Your own behalf and on Your sole responsibility, not on behalf
++   of any other Contributor, and only if You agree to indemnify,
++   defend, and hold each Contributor harmless for any liability
++   incurred by, or claims asserted against, such Contributor by reason
++   of your accepting any such warranty or additional liability.
++
++END OF TERMS AND CONDITIONS
+diff --git a/third_party/rust/rustversion/LICENSE-MIT b/third_party/rust/rustversion/LICENSE-MIT
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/LICENSE-MIT
+@@ -0,0 +1,23 @@
++Permission is hereby granted, free of charge, to any
++person obtaining a copy of this software and associated
++documentation files (the "Software"), to deal in the
++Software without restriction, including without
++limitation the rights to use, copy, modify, merge,
++publish, distribute, sublicense, and/or sell copies of
++the Software, and to permit persons to whom the Software
++is furnished to do so, subject to the following
++conditions:
++
++The above copyright notice and this permission notice
++shall be included in all copies or substantial portions
++of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
++ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
++TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
++PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
++SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
++OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
++IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++DEALINGS IN THE SOFTWARE.
+diff --git a/third_party/rust/rustversion/README.md b/third_party/rust/rustversion/README.md
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/README.md
+@@ -0,0 +1,167 @@
++Compiler version cfg
++====================
++
++[<img alt="github" src="https://img.shields.io/badge/github-dtolnay/rustversion-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/dtolnay/rustversion)
++[<img alt="crates.io" src="https://img.shields.io/crates/v/rustversion.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/rustversion)
++[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-rustversion-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" height="20">](https://docs.rs/rustversion)
++[<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/dtolnay/rustversion/ci.yml?branch=master&style=for-the-badge" height="20">](https://github.com/dtolnay/rustversion/actions?query=branch%3Amaster)
++
++This crate provides macros for conditional compilation according to rustc
++compiler version, analogous to [`#[cfg(...)]`][cfg] and
++[`#[cfg_attr(...)]`][cfg_attr].
++
++[cfg]: https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute
++[cfg_attr]: https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute
++
++```toml
++[dependencies]
++rustversion = "1.0"
++```
++
++<br>
++
++## Selectors
++
++- <b>`#[rustversion::stable]`</b>
++  —<br>
++  True on any stable compiler.
++
++- <b>`#[rustversion::stable(1.34)]`</b>
++  —<br>
++  True on exactly the specified stable compiler.
++
++- <b>`#[rustversion::beta]`</b>
++  —<br>
++  True on any beta compiler.
++
++- <b>`#[rustversion::nightly]`</b>
++  —<br>
++  True on any nightly compiler or dev build.
++
++- <b>`#[rustversion::nightly(2025-01-01)]`</b>
++  —<br>
++  True on exactly one nightly.
++
++- <b>`#[rustversion::since(1.34)]`</b>
++  —<br>
++  True on that stable release and any later compiler, including beta and
++  nightly.
++
++- <b>`#[rustversion::since(2025-01-01)]`</b>
++  —<br>
++  True on that nightly and all newer ones.
++
++- <b>`#[rustversion::before(`</b><i>version or date</i><b>`)]`</b>
++  —<br>
++  Negative of *#[rustversion::since(...)]*.
++
++- <b>`#[rustversion::not(`</b><i>selector</i><b>`)]`</b>
++  —<br>
++  Negative of any selector; for example *#[rustversion::not(nightly)]*.
++
++- <b>`#[rustversion::any(`</b><i>selectors...</i><b>`)]`</b>
++  —<br>
++  True if any of the comma-separated selectors is true; for example
++  *#[rustversion::any(stable, beta)]*.
++
++- <b>`#[rustversion::all(`</b><i>selectors...</i><b>`)]`</b>
++  —<br>
++  True if all of the comma-separated selectors are true; for example
++  *#[rustversion::all(since(1.31), before(1.34))]*.
++
++- <b>`#[rustversion::attr(`</b><i>selector</i><b>`, `</b><i>attribute</i><b>`)]`</b>
++  —<br>
++  For conditional inclusion of attributes; analogous to `cfg_attr`.
++
++- <b>`rustversion::cfg!(`</b><i>selector</i><b>`)`</b>
++  —<br>
++  An expression form of any of the above attributes; for example
++  *if rustversion::cfg!(any(stable, beta)) { ... }*.
++
++<br>
++
++## Use cases
++
++Providing additional trait impls as types are stabilized in the standard library
++without breaking compatibility with older compilers; in this case Pin\<P\>
++stabilized in [Rust 1.33][pin]:
++
++[pin]: https://blog.rust-lang.org/2019/02/28/Rust-1.33.0.html#pinning
++
++```rust
++#[rustversion::since(1.33)]
++use std::pin::Pin;
++
++#[rustversion::since(1.33)]
++impl<P: MyTrait> MyTrait for Pin<P> {
++    /* ... */
++}
++```
++
++Similar but for language features; the ability to control alignment greater than
++1 of packed structs was stabilized in [Rust 1.33][packed].
++
++[packed]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1330-2019-02-28
++
++```rust
++#[rustversion::attr(before(1.33), repr(packed))]
++#[rustversion::attr(since(1.33), repr(packed(2)))]
++struct Six(i16, i32);
++
++fn main() {
++    println!("{}", std::mem::align_of::<Six>());
++}
++```
++
++Augmenting code with `const` as const impls are stabilized in the standard
++library. This use of `const` as an attribute is recognized as a special case by
++the rustversion::attr macro.
++
++```rust
++use std::time::Duration;
++
++#[rustversion::attr(since(1.32), const)]
++fn duration_as_days(dur: Duration) -> u64 {
++    dur.as_secs() / 60 / 60 / 24
++}
++```
++
++Emitting Cargo cfg directives from a build script. Note that this requires
++listing `rustversion` under `[build-dependencies]` in Cargo.toml, not
++`[dependencies]`.
++
++```rust
++// build.rs
++
++fn main() {
++    if rustversion::cfg!(since(1.36)) {
++        println!("cargo:rustc-cfg=no_std");
++    }
++}
++```
++
++```rust
++// src/lib.rs
++
++#![cfg_attr(no_std, no_std)]
++
++#[cfg(no_std)]
++extern crate alloc;
++```
++
++<br>
++
++#### License
++
++<sup>
++Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
++2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
++</sup>
++
++<br>
++
++<sub>
++Unless you explicitly state otherwise, any contribution intentionally submitted
++for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
++be dual licensed as above, without any additional terms or conditions.
++</sub>
+diff --git a/third_party/rust/rustversion/build/build.rs b/third_party/rust/rustversion/build/build.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/build/build.rs
+@@ -0,0 +1,119 @@
++#![allow(
++    clippy::elidable_lifetime_names,
++    clippy::enum_glob_use,
++    clippy::must_use_candidate,
++    clippy::single_match_else
++)]
++
++mod rustc;
++
++use std::env;
++use std::ffi::OsString;
++use std::fmt::{self, Debug, Display};
++use std::fs;
++use std::iter;
++use std::path::Path;
++use std::process::{self, Command};
++
++fn main() {
++    println!("cargo:rerun-if-changed=build/build.rs");
++
++    let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
++    let rustc_wrapper = env::var_os("RUSTC_WRAPPER").filter(|wrapper| !wrapper.is_empty());
++    let wrapped_rustc = rustc_wrapper.iter().chain(iter::once(&rustc));
++
++    let mut is_clippy_driver = false;
++    let mut is_mirai = false;
++    let version = loop {
++        let mut command;
++        if is_mirai {
++            command = Command::new(&rustc);
++        } else {
++            let mut wrapped_rustc = wrapped_rustc.clone();
++            command = Command::new(wrapped_rustc.next().unwrap());
++            command.args(wrapped_rustc);
++        }
++        if is_clippy_driver {
++            command.arg("--rustc");
++        }
++        command.arg("--version");
++
++        // Allow wrapper scripts or alternate compilers to tell that this is
++        // `rustversion` running --version, so that they can stick to rustc's
++        // version format. https://github.com/dtolnay/rustversion/issues/67
++        command.env("RUSTVERSION", "1");
++
++        let output = match command.output() {
++            Ok(output) => output,
++            Err(e) => {
++                let rustc = rustc.to_string_lossy();
++                eprintln!("Error: failed to run `{} --version`: {}", rustc, e);
++                process::exit(1);
++            }
++        };
++
++        let string = match String::from_utf8(output.stdout) {
++            Ok(string) => string,
++            Err(e) => {
++                let rustc = rustc.to_string_lossy();
++                eprintln!(
++                    "Error: failed to parse output of `{} --version`: {}",
++                    rustc, e,
++                );
++                process::exit(1);
++            }
++        };
++
++        break match rustc::parse(&string) {
++            rustc::ParseResult::Success(version) => version,
++            rustc::ParseResult::OopsClippy if !is_clippy_driver => {
++                is_clippy_driver = true;
++                continue;
++            }
++            rustc::ParseResult::OopsMirai if !is_mirai && rustc_wrapper.is_some() => {
++                is_mirai = true;
++                continue;
++            }
++            rustc::ParseResult::Unrecognized
++            | rustc::ParseResult::OopsClippy
++            | rustc::ParseResult::OopsMirai => {
++                eprintln!(
++                    "Error: unexpected output from `rustc --version`: {:?}\n\n\
++                    Please file an issue in https://github.com/dtolnay/rustversion",
++                    string
++                );
++                process::exit(1);
++            }
++        };
++    };
++
++    if version.minor < 38 {
++        // Prior to 1.38, a #[proc_macro] is not allowed to be named `cfg`.
++        println!("cargo:rustc-cfg=cfg_macro_not_allowed");
++    }
++
++    if version.minor >= 80 {
++        println!("cargo:rustc-check-cfg=cfg(cfg_macro_not_allowed)");
++        println!("cargo:rustc-check-cfg=cfg(host_os, values(\"windows\"))");
++    }
++
++    let version = format!("{:#}\n", Render(&version));
++    let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR not set");
++    let out_file = Path::new(&out_dir).join("version.expr");
++    fs::write(out_file, version).expect("failed to write version.expr");
++
++    let host = env::var_os("HOST").expect("HOST not set");
++    if let Some("windows") = host.to_str().unwrap().split('-').nth(2) {
++        println!("cargo:rustc-cfg=host_os=\"windows\"");
++    }
++}
++
++// Shim Version's {:?} format into a {} format, because {:?} is unusable in
++// format strings when building with `-Zfmt-debug=none`.
++struct Render<'a>(&'a rustc::Version);
++
++impl<'a> Display for Render<'a> {
++    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
++        Debug::fmt(self.0, formatter)
++    }
++}
+diff --git a/third_party/rust/rustversion/build/rustc.rs b/third_party/rust/rustversion/build/rustc.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/build/rustc.rs
+@@ -0,0 +1,126 @@
++use self::Channel::*;
++use std::fmt::{self, Debug};
++
++pub enum ParseResult {
++    Success(Version),
++    OopsClippy,
++    OopsMirai,
++    Unrecognized,
++}
++
++#[cfg_attr(test, derive(PartialEq))]
++pub struct Version {
++    pub minor: u16,
++    pub patch: u16,
++    pub channel: Channel,
++}
++
++#[cfg_attr(test, derive(PartialEq))]
++pub enum Channel {
++    Stable,
++    Beta,
++    Nightly(Date),
++    Dev,
++}
++
++#[cfg_attr(test, derive(PartialEq))]
++pub struct Date {
++    pub year: u16,
++    pub month: u8,
++    pub day: u8,
++}
++
++pub fn parse(string: &str) -> ParseResult {
++    let last_line = string.lines().last().unwrap_or(string);
++    let mut words = last_line.trim().split(' ');
++
++    match words.next() {
++        Some("rustc") => {}
++        Some(word) if word.starts_with("clippy") => return ParseResult::OopsClippy,
++        Some("mirai") => return ParseResult::OopsMirai,
++        Some(_) | None => return ParseResult::Unrecognized,
++    }
++
++    parse_words(&mut words).map_or(ParseResult::Unrecognized, ParseResult::Success)
++}
++
++fn parse_words(words: &mut dyn Iterator<Item = &str>) -> Option<Version> {
++    let mut version_channel = words.next()?.split('-');
++    let version = version_channel.next()?;
++    let channel = version_channel.next();
++
++    let mut digits = version.split('.');
++    let major = digits.next()?;
++    if major != "1" {
++        return None;
++    }
++    let minor = digits.next()?.parse().ok()?;
++    let patch = digits.next().unwrap_or("0").parse().ok()?;
++
++    let channel = match channel {
++        None => Stable,
++        Some("dev") => Dev,
++        Some(channel) if channel.starts_with("beta") => Beta,
++        Some("nightly") => match words.next() {
++            Some(hash) if hash.starts_with('(') => match words.next() {
++                None if hash.ends_with(')') => Dev,
++                Some(date) if date.ends_with(')') => {
++                    let mut date = date[..date.len() - 1].split('-');
++                    let year = date.next()?.parse().ok()?;
++                    let month = date.next()?.parse().ok()?;
++                    let day = date.next()?.parse().ok()?;
++                    match date.next() {
++                        None => Nightly(Date { year, month, day }),
++                        Some(_) => return None,
++                    }
++                }
++                None | Some(_) => return None,
++            },
++            Some(_) => return None,
++            None => Dev,
++        },
++        Some(_) => return None,
++    };
++
++    Some(Version {
++        minor,
++        patch,
++        channel,
++    })
++}
++
++impl Debug for Version {
++    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
++        formatter
++            .debug_struct("crate::version::Version")
++            .field("minor", &self.minor)
++            .field("patch", &self.patch)
++            .field("channel", &self.channel)
++            .finish()
++    }
++}
++
++impl Debug for Channel {
++    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
++        match self {
++            Channel::Stable => formatter.write_str("crate::version::Channel::Stable"),
++            Channel::Beta => formatter.write_str("crate::version::Channel::Beta"),
++            Channel::Nightly(date) => formatter
++                .debug_tuple("crate::version::Channel::Nightly")
++                .field(date)
++                .finish(),
++            Channel::Dev => formatter.write_str("crate::version::Channel::Dev"),
++        }
++    }
++}
++
++impl Debug for Date {
++    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
++        formatter
++            .debug_struct("crate::date::Date")
++            .field("year", &self.year)
++            .field("month", &self.month)
++            .field("day", &self.day)
++            .finish()
++    }
++}
+diff --git a/third_party/rust/rustversion/src/attr.rs b/third_party/rust/rustversion/src/attr.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/attr.rs
+@@ -0,0 +1,35 @@
++use crate::error::{Error, Result};
++use crate::expr::{self, Expr};
++use crate::{iter, token};
++use proc_macro::{Span, TokenStream};
++
++pub struct Args {
++    pub condition: Expr,
++    pub then: Then,
++}
++
++pub enum Then {
++    Const(Span),
++    Attribute(TokenStream),
++}
++
++pub fn parse(input: TokenStream) -> Result<Args> {
++    let ref mut input = iter::new(input);
++    let condition = expr::parse(input)?;
++
++    token::parse_punct(input, ',')?;
++    if input.peek().is_none() {
++        return Err(Error::new(Span::call_site(), "expected one or more attrs"));
++    }
++
++    let const_span = token::parse_optional_keyword(input, "const");
++    let then = if let Some(const_span) = const_span {
++        token::parse_optional_punct(input, ',');
++        token::parse_end(input)?;
++        Then::Const(const_span)
++    } else {
++        Then::Attribute(input.collect())
++    };
++
++    Ok(Args { condition, then })
++}
+diff --git a/third_party/rust/rustversion/src/bound.rs b/third_party/rust/rustversion/src/bound.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/bound.rs
+@@ -0,0 +1,63 @@
++use crate::date::{self, Date};
++use crate::error::{Error, Result};
++use crate::iter::Iter;
++use crate::release::{self, Release};
++use crate::time;
++use crate::version::{Channel::*, Version};
++use proc_macro::{Group, TokenTree};
++use std::cmp::Ordering;
++
++pub enum Bound {
++    Nightly(Date),
++    Stable(Release),
++}
++
++pub fn parse(paren: Group, iter: Iter) -> Result<Bound> {
++    if let Some(TokenTree::Literal(literal)) = iter.peek() {
++        let repr = literal.to_string();
++        if repr.starts_with(|ch: char| ch.is_ascii_digit()) {
++            if repr.contains('.') {
++                return release::parse(paren, iter).map(Bound::Stable);
++            } else {
++                return date::parse(paren, iter).map(Bound::Nightly);
++            }
++        }
++    }
++    let msg = format!(
++        "expected rustc release number like 1.85, or nightly date like {}",
++        time::today(),
++    );
++    Err(Error::group(paren, msg))
++}
++
++impl PartialEq<Bound> for Version {
++    fn eq(&self, rhs: &Bound) -> bool {
++        match rhs {
++            Bound::Nightly(date) => match self.channel {
++                Stable | Beta | Dev => false,
++                Nightly(nightly) => nightly == *date,
++            },
++            Bound::Stable(release) => {
++                self.minor == release.minor
++                    && release.patch.map_or(true, |patch| self.patch == patch)
++            }
++        }
++    }
++}
++
++impl PartialOrd<Bound> for Version {
++    fn partial_cmp(&self, rhs: &Bound) -> Option<Ordering> {
++        match rhs {
++            Bound::Nightly(date) => match self.channel {
++                Stable | Beta => Some(Ordering::Less),
++                Nightly(nightly) => Some(nightly.cmp(date)),
++                Dev => Some(Ordering::Greater),
++            },
++            Bound::Stable(release) => {
++                let version = (self.minor, self.patch);
++                let bound = (release.minor, release.patch.unwrap_or(0));
++                Some(version.cmp(&bound))
++            }
++        }
++    }
++}
+diff --git a/third_party/rust/rustversion/src/constfn.rs b/third_party/rust/rustversion/src/constfn.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/constfn.rs
+@@ -0,0 +1,58 @@
++use crate::error::{Error, Result};
++use proc_macro::{Ident, Span, TokenStream, TokenTree};
++use std::iter;
++
++#[derive(PartialOrd, PartialEq)]
++enum Qualifiers {
++    None,
++    Async,
++    Unsafe,
++    Extern,
++    Abi,
++}
++
++impl Qualifiers {
++    fn from_ident(ident: &Ident) -> Self {
++        match ident.to_string().as_str() {
++            "async" => Qualifiers::Async,
++            "unsafe" => Qualifiers::Unsafe,
++            "extern" => Qualifiers::Extern,
++            _ => Qualifiers::None,
++        }
++    }
++}
++
++pub(crate) fn insert_const(input: TokenStream, const_span: Span) -> Result<TokenStream> {
++    let ref mut input = crate::iter::new(input);
++    let mut out = TokenStream::new();
++    let mut qualifiers = Qualifiers::None;
++    let mut pending = Vec::new();
++
++    while let Some(token) = input.next() {
++        match token {
++            TokenTree::Ident(ref ident) if ident.to_string() == "fn" => {
++                let const_ident = Ident::new("const", const_span);
++                out.extend(iter::once(TokenTree::Ident(const_ident)));
++                out.extend(pending);
++                out.extend(iter::once(token));
++                out.extend(input);
++                return Ok(out);
++            }
++            TokenTree::Ident(ref ident) if Qualifiers::from_ident(ident) > qualifiers => {
++                qualifiers = Qualifiers::from_ident(ident);
++                pending.push(token);
++            }
++            TokenTree::Literal(_) if qualifiers == Qualifiers::Extern => {
++                qualifiers = Qualifiers::Abi;
++                pending.push(token);
++            }
++            _ => {
++                qualifiers = Qualifiers::None;
++                out.extend(pending.drain(..));
++                out.extend(iter::once(token));
++            }
++        }
++    }
++
++    Err(Error::new(const_span, "only allowed on a fn item"))
++}
+diff --git a/third_party/rust/rustversion/src/date.rs b/third_party/rust/rustversion/src/date.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/date.rs
+@@ -0,0 +1,50 @@
++use crate::error::{Error, Result};
++use crate::iter::Iter;
++use crate::{time, token};
++use proc_macro::Group;
++use std::fmt::{self, Display};
++
++#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
++pub struct Date {
++    pub year: u16,
++    pub month: u8,
++    pub day: u8,
++}
++
++impl Display for Date {
++    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
++        write!(
++            formatter,
++            "{:04}-{:02}-{:02}",
++            self.year, self.month, self.day,
++        )
++    }
++}
++
++pub fn parse(paren: Group, iter: Iter) -> Result<Date> {
++    try_parse(iter).map_err(|()| {
++        let msg = format!("expected nightly date, like {}", time::today());
++        Error::group(paren, msg)
++    })
++}
++
++fn try_parse(iter: Iter) -> Result<Date, ()> {
++    let year = token::parse_literal(iter).map_err(drop)?;
++    token::parse_punct(iter, '-').map_err(drop)?;
++    let month = token::parse_literal(iter).map_err(drop)?;
++    token::parse_punct(iter, '-').map_err(drop)?;
++    let day = token::parse_literal(iter).map_err(drop)?;
++
++    let year = year.to_string().parse::<u64>().map_err(drop)?;
++    let month = month.to_string().parse::<u64>().map_err(drop)?;
++    let day = day.to_string().parse::<u64>().map_err(drop)?;
++    if year >= 3000 || month > 12 || day > 31 {
++        return Err(());
++    }
++
++    Ok(Date {
++        year: year as u16,
++        month: month as u8,
++        day: day as u8,
++    })
++}
+diff --git a/third_party/rust/rustversion/src/error.rs b/third_party/rust/rustversion/src/error.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/error.rs
+@@ -0,0 +1,56 @@
++use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
++use std::fmt::Display;
++use std::iter::FromIterator;
++
++pub type Result<T, E = Error> = std::result::Result<T, E>;
++
++pub struct Error {
++    begin: Span,
++    end: Span,
++    msg: String,
++}
++
++impl Error {
++    pub fn new(span: Span, msg: impl Display) -> Self {
++        Self::new2(span, span, msg)
++    }
++
++    pub fn new2(begin: Span, end: Span, msg: impl Display) -> Self {
++        Error {
++            begin,
++            end,
++            msg: msg.to_string(),
++        }
++    }
++
++    pub fn group(group: Group, msg: impl Display) -> Self {
++        let mut iter = group.stream().into_iter();
++        let delimiter = group.span();
++        let begin = iter.next().map_or(delimiter, |t| t.span());
++        let end = iter.last().map_or(begin, |t| t.span());
++        Self::new2(begin, end, msg)
++    }
++
++    pub fn into_compile_error(self) -> TokenStream {
++        // compile_error! { $msg }
++        TokenStream::from_iter(vec![
++            TokenTree::Ident(Ident::new("compile_error", self.begin)),
++            TokenTree::Punct({
++                let mut punct = Punct::new('!', Spacing::Alone);
++                punct.set_span(self.begin);
++                punct
++            }),
++            TokenTree::Group({
++                let mut group = Group::new(Delimiter::Brace, {
++                    TokenStream::from_iter(vec![TokenTree::Literal({
++                        let mut string = Literal::string(&self.msg);
++                        string.set_span(self.end);
++                        string
++                    })])
++                });
++                group.set_span(self.end);
++                group
++            }),
++        ])
++    }
++}
+diff --git a/third_party/rust/rustversion/src/expand.rs b/third_party/rust/rustversion/src/expand.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/expand.rs
+@@ -0,0 +1,100 @@
++use crate::attr::{self, Then};
++use crate::error::{Error, Result};
++use crate::{constfn, expr, iter, token};
++use proc_macro::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
++use std::iter::FromIterator;
++
++pub fn cfg(introducer: &str, args: TokenStream, input: TokenStream) -> TokenStream {
++    try_cfg(introducer, args, input).unwrap_or_else(Error::into_compile_error)
++}
++
++fn try_cfg(introducer: &str, args: TokenStream, input: TokenStream) -> Result<TokenStream> {
++    let introducer = Ident::new(introducer, Span::call_site());
++
++    let mut full_args = TokenStream::from(TokenTree::Ident(introducer));
++    if !args.is_empty() {
++        full_args.extend(std::iter::once(TokenTree::Group(Group::new(
++            Delimiter::Parenthesis,
++            args,
++        ))));
++    }
++
++    let ref mut full_args = iter::new(full_args);
++    let expr = expr::parse(full_args)?;
++    token::parse_end(full_args)?;
++
++    if expr.eval(crate::RUSTVERSION) {
++        Ok(allow_incompatible_msrv(input))
++    } else {
++        Ok(TokenStream::new())
++    }
++}
++
++pub fn try_attr(args: attr::Args, input: TokenStream) -> Result<TokenStream> {
++    if !args.condition.eval(crate::RUSTVERSION) {
++        return Ok(input);
++    }
++
++    let output = match args.then {
++        Then::Const(const_token) => constfn::insert_const(input, const_token)?,
++        Then::Attribute(then) => {
++            TokenStream::from_iter(
++                // #[cfg_attr(all(), #then)]
++                vec![
++                    TokenTree::Punct(Punct::new('#', Spacing::Alone)),
++                    TokenTree::Group(Group::new(
++                        Delimiter::Bracket,
++                        TokenStream::from_iter(vec![
++                            TokenTree::Ident(Ident::new("cfg_attr", Span::call_site())),
++                            TokenTree::Group(Group::new(
++                                Delimiter::Parenthesis,
++                                TokenStream::from_iter(
++                                    vec![
++                                        TokenTree::Ident(Ident::new("all", Span::call_site())),
++                                        TokenTree::Group(Group::new(
++                                            Delimiter::Parenthesis,
++                                            TokenStream::new(),
++                                        )),
++                                        TokenTree::Punct(Punct::new(',', Spacing::Alone)),
++                                    ]
++                                    .into_iter()
++                                    .chain(then),
++                                ),
++                            )),
++                        ]),
++                    )),
++                ]
++                .into_iter()
++                .chain(input),
++            )
++        }
++    };
++
++    Ok(allow_incompatible_msrv(output))
++}
++
++fn allow_incompatible_msrv(input: TokenStream) -> TokenStream {
++    TokenStream::from_iter(
++        // #[allow(clippy::incompatible_msrv)]
++        vec![
++            TokenTree::Punct(Punct::new('#', Spacing::Alone)),
++            TokenTree::Group(Group::new(
++                Delimiter::Bracket,
++                TokenStream::from_iter(vec![
++                    TokenTree::Ident(Ident::new("allow", Span::call_site())),
++                    TokenTree::Group(Group::new(
++                        Delimiter::Parenthesis,
++                        TokenStream::from_iter(vec![
++                            TokenTree::Ident(Ident::new("clippy", Span::call_site())),
++                            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
++                            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
++                            TokenTree::Ident(Ident::new("incompatible_msrv", Span::call_site())),
++                        ]),
++                    )),
++                ]),
++            )),
++        ]
++        .into_iter()
++        .chain(input),
++    )
++}
+diff --git a/third_party/rust/rustversion/src/expr.rs b/third_party/rust/rustversion/src/expr.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/expr.rs
+@@ -0,0 +1,163 @@
++use crate::bound::{self, Bound};
++use crate::date::{self, Date};
++use crate::error::{Error, Result};
++use crate::iter::{self, Iter};
++use crate::release::{self, Release};
++use crate::token;
++use crate::version::{Channel, Version};
++use proc_macro::{Ident, Span, TokenTree};
++
++pub enum Expr {
++    Stable,
++    Beta,
++    Nightly,
++    Date(Date),
++    Since(Bound),
++    Before(Bound),
++    Release(Release),
++    Not(Box<Expr>),
++    Any(Vec<Expr>),
++    All(Vec<Expr>),
++}
++
++impl Expr {
++    pub fn eval(&self, rustc: Version) -> bool {
++        use self::Expr::*;
++
++        match self {
++            Stable => rustc.channel == Channel::Stable,
++            Beta => rustc.channel == Channel::Beta,
++            Nightly => match rustc.channel {
++                Channel::Nightly(_) | Channel::Dev => true,
++                Channel::Stable | Channel::Beta => false,
++            },
++            Date(date) => match rustc.channel {
++                Channel::Nightly(rustc) => rustc == *date,
++                Channel::Stable | Channel::Beta | Channel::Dev => false,
++            },
++            Since(bound) => rustc >= *bound,
++            Before(bound) => rustc < *bound,
++            Release(release) => {
++                rustc.channel == Channel::Stable
++                    && rustc.minor == release.minor
++                    && release.patch.map_or(true, |patch| rustc.patch == patch)
++            }
++            Not(expr) => !expr.eval(rustc),
++            Any(exprs) => exprs.iter().any(|e| e.eval(rustc)),
++            All(exprs) => exprs.iter().all(|e| e.eval(rustc)),
++        }
++    }
++}
++
++pub fn parse(iter: Iter) -> Result<Expr> {
++    match &iter.next() {
++        Some(TokenTree::Ident(i)) if i.to_string() == "stable" => parse_stable(iter),
++        Some(TokenTree::Ident(i)) if i.to_string() == "beta" => Ok(Expr::Beta),
++        Some(TokenTree::Ident(i)) if i.to_string() == "nightly" => parse_nightly(iter),
++        Some(TokenTree::Ident(i)) if i.to_string() == "since" => parse_since(i, iter),
++        Some(TokenTree::Ident(i)) if i.to_string() == "before" => parse_before(i, iter),
++        Some(TokenTree::Ident(i)) if i.to_string() == "not" => parse_not(i, iter),
++        Some(TokenTree::Ident(i)) if i.to_string() == "any" => parse_any(i, iter),
++        Some(TokenTree::Ident(i)) if i.to_string() == "all" => parse_all(i, iter),
++        unexpected => {
++            let span = unexpected
++                .as_ref()
++                .map_or_else(Span::call_site, TokenTree::span);
++            Err(Error::new(span, "expected one of `stable`, `beta`, `nightly`, `since`, `before`, `not`, `any`, `all`"))
++        }
++    }
++}
++
++fn parse_nightly(iter: Iter) -> Result<Expr> {
++    let paren = match token::parse_optional_paren(iter) {
++        Some(group) => group,
++        None => return Ok(Expr::Nightly),
++    };
++
++    let ref mut inner = iter::new(paren.stream());
++    let date = date::parse(paren, inner)?;
++    token::parse_optional_punct(inner, ',');
++    token::parse_end(inner)?;
++
++    Ok(Expr::Date(date))
++}
++
++fn parse_stable(iter: Iter) -> Result<Expr> {
++    let paren = match token::parse_optional_paren(iter) {
++        Some(group) => group,
++        None => return Ok(Expr::Stable),
++    };
++
++    let ref mut inner = iter::new(paren.stream());
++    let release = release::parse(paren, inner)?;
++    token::parse_optional_punct(inner, ',');
++    token::parse_end(inner)?;
++
++    Ok(Expr::Release(release))
++}
++
++fn parse_since(introducer: &Ident, iter: Iter) -> Result<Expr> {
++    let paren = token::parse_paren(introducer, iter)?;
++
++    let ref mut inner = iter::new(paren.stream());
++    let bound = bound::parse(paren, inner)?;
++    token::parse_optional_punct(inner, ',');
++    token::parse_end(inner)?;
++
++    Ok(Expr::Since(bound))
++}
++
++fn parse_before(introducer: &Ident, iter: Iter) -> Result<Expr> {
++    let paren = token::parse_paren(introducer, iter)?;
++
++    let ref mut inner = iter::new(paren.stream());
++    let bound = bound::parse(paren, inner)?;
++    token::parse_optional_punct(inner, ',');
++    token::parse_end(inner)?;
++
++    Ok(Expr::Before(bound))
++}
++
++fn parse_not(introducer: &Ident, iter: Iter) -> Result<Expr> {
++    let paren = token::parse_paren(introducer, iter)?;
++
++    let ref mut inner = iter::new(paren.stream());
++    let expr = self::parse(inner)?;
++    token::parse_optional_punct(inner, ',');
++    token::parse_end(inner)?;
++
++    Ok(Expr::Not(Box::new(expr)))
++}
++
++fn parse_any(introducer: &Ident, iter: Iter) -> Result<Expr> {
++    let paren = token::parse_paren(introducer, iter)?;
++
++    let ref mut inner = iter::new(paren.stream());
++    let exprs = parse_comma_separated(inner)?;
++
++    Ok(Expr::Any(exprs.into_iter().collect()))
++}
++
++fn parse_all(introducer: &Ident, iter: Iter) -> Result<Expr> {
++    let paren = token::parse_paren(introducer, iter)?;
++
++    let ref mut inner = iter::new(paren.stream());
++    let exprs = parse_comma_separated(inner)?;
++
++    Ok(Expr::All(exprs.into_iter().collect()))
++}
++
++fn parse_comma_separated(iter: Iter) -> Result<Vec<Expr>> {
++    let mut exprs = Vec::new();
++
++    while iter.peek().is_some() {
++        let expr = self::parse(iter)?;
++        exprs.push(expr);
++        if iter.peek().is_none() {
++            break;
++        }
++        token::parse_punct(iter, ',')?;
++    }
++
++    Ok(exprs)
++}
+diff --git a/third_party/rust/rustversion/src/iter.rs b/third_party/rust/rustversion/src/iter.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/iter.rs
+@@ -0,0 +1,42 @@
++use proc_macro::{token_stream, Delimiter, TokenStream, TokenTree};
++
++pub type Iter<'a> = &'a mut IterImpl;
++
++pub struct IterImpl {
++    stack: Vec<token_stream::IntoIter>,
++    peeked: Option<TokenTree>,
++}
++
++pub fn new(tokens: TokenStream) -> IterImpl {
++    IterImpl {
++        stack: vec![tokens.into_iter()],
++        peeked: None,
++    }
++}
++
++impl IterImpl {
++    pub fn peek(&mut self) -> Option<&TokenTree> {
++        self.peeked = self.next();
++        self.peeked.as_ref()
++    }
++}
++
++impl Iterator for IterImpl {
++    type Item = TokenTree;
++
++    fn next(&mut self) -> Option<Self::Item> {
++        if let Some(tt) = self.peeked.take() {
++            return Some(tt);
++        }
++        loop {
++            let top = self.stack.last_mut()?;
++            match top.next() {
++                None => drop(self.stack.pop()),
++                Some(TokenTree::Group(ref group)) if group.delimiter() == Delimiter::None => {
++                    self.stack.push(group.stream().into_iter());
++                }
++                Some(tt) => return Some(tt),
++            }
++        }
++    }
++}
+diff --git a/third_party/rust/rustversion/src/lib.rs b/third_party/rust/rustversion/src/lib.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/lib.rs
+@@ -0,0 +1,281 @@
++//! [![github]](https://github.com/dtolnay/rustversion)&ensp;[![crates-io]](https://crates.io/crates/rustversion)&ensp;[![docs-rs]](https://docs.rs/rustversion)
++//!
++//! [github]: https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github
++//! [crates-io]: https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust
++//! [docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
++//!
++//! <br>
++//!
++//! This crate provides macros for conditional compilation according to rustc
++//! compiler version, analogous to [`#[cfg(...)]`][cfg] and
++//! [`#[cfg_attr(...)]`][cfg_attr].
++//!
++//! [cfg]: https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute
++//! [cfg_attr]: https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute
++//!
++//! <br>
++//!
++//! # Selectors
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::stable]</code></b>
++//!   —<br>
++//!   True on any stable compiler.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::stable(1.34)]</code></b>
++//!   —<br>
++//!   True on exactly the specified stable compiler.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::beta]</code></b>
++//!   —<br>
++//!   True on any beta compiler.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::nightly]</code></b>
++//!   —<br>
++//!   True on any nightly compiler or dev build.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::nightly(2025-01-01)]</code></b>
++//!   —<br>
++//!   True on exactly one nightly.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::since(1.34)]</code></b>
++//!   —<br>
++//!   True on that stable release and any later compiler, including beta and
++//!   nightly.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::since(2025-01-01)]</code></b>
++//!   —<br>
++//!   True on that nightly and all newer ones.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::before(</code></b><i>version or date</i><b><code style="display:inline">)]</code></b>
++//!   —<br>
++//!   Negative of <i>#[rustversion::since(...)]</i>.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::not(</code></b><i>selector</i><b><code style="display:inline">)]</code></b>
++//!   —<br>
++//!   Negative of any selector; for example <i>#[rustversion::not(nightly)]</i>.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::any(</code></b><i>selectors...</i><b><code style="display:inline">)]</code></b>
++//!   —<br>
++//!   True if any of the comma-separated selectors is true; for example
++//!   <i>#[rustversion::any(stable, beta)]</i>.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::all(</code></b><i>selectors...</i><b><code style="display:inline">)]</code></b>
++//!   —<br>
++//!   True if all of the comma-separated selectors are true; for example
++//!   <i>#[rustversion::all(since(1.31), before(1.34))]</i>.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">#[rustversion::attr(</code></b><i>selector</i><b><code style="display:inline">, </code></b><i>attribute</i><b><code style="display:inline">)]</code></b>
++//!   —<br>
++//!   For conditional inclusion of attributes; analogous to
++//!   <code style="display:inline">cfg_attr</code>.
++//!   </p>
++//!
++//! - <p style="margin-left:50px;text-indent:-50px">
++//!   <b><code style="display:inline">rustversion::cfg!(</code></b><i>selector</i><b><code style="display:inline">)</code></b>
++//!   —<br>
++//!   An expression form of any of the above attributes; for example
++//!   <i>if rustversion::cfg!(any(stable, beta)) { ... }</i>.
++//!   </p>
++//!
++//! <br>
++//!
++//! # Use cases
++//!
++//! Providing additional trait impls as types are stabilized in the standard library
++//! without breaking compatibility with older compilers; in this case Pin\<P\>
++//! stabilized in [Rust 1.33][pin]:
++//!
++//! [pin]: https://blog.rust-lang.org/2019/02/28/Rust-1.33.0.html#pinning
++//!
++//! ```
++//! # trait MyTrait {}
++//! #
++//! #[rustversion::since(1.33)]
++//! use std::pin::Pin;
++//!
++//! #[rustversion::since(1.33)]
++//! impl<P: MyTrait> MyTrait for Pin<P> {
++//!     /* ... */
++//! }
++//! ```
++//!
++//! Similar but for language features; the ability to control alignment greater than
++//! 1 of packed structs was stabilized in [Rust 1.33][packed].
++//!
++//! [packed]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1330-2019-02-28
++//!
++//! ```
++//! #[rustversion::attr(before(1.33), repr(packed))]
++//! #[rustversion::attr(since(1.33), repr(packed(2)))]
++//! struct Six(i16, i32);
++//!
++//! fn main() {
++//!     println!("{}", std::mem::align_of::<Six>());
++//! }
++//! ```
++//!
++//! Augmenting code with `const` as const impls are stabilized in the standard
++//! library. This use of `const` as an attribute is recognized as a special case
++//! by the rustversion::attr macro.
++//!
++//! ```
++//! use std::time::Duration;
++//!
++//! #[rustversion::attr(since(1.32), const)]
++//! fn duration_as_days(dur: Duration) -> u64 {
++//!     dur.as_secs() / 60 / 60 / 24
++//! }
++//! ```
++//!
++//! Emitting Cargo cfg directives from a build script. Note that this requires
++//! listing `rustversion` under `[build-dependencies]` in Cargo.toml, not
++//! `[dependencies]`.
++//!
++//! ```
++//! // build.rs
++//!
++//! fn main() {
++//!     if rustversion::cfg!(since(1.36)) {
++//!         println!("cargo:rustc-cfg=no_std");
++//!     }
++//! }
++//! ```
++//!
++//! ```
++//! // src/lib.rs
++//!
++//! #![cfg_attr(no_std, no_std)]
++//!
++//! #[cfg(no_std)]
++//! extern crate alloc;
++//! ```
++//!
++//! <br>
++
++#![doc(html_root_url = "https://docs.rs/rustversion/1.0.23")]
++#![allow(
++    clippy::cast_lossless,
++    clippy::cast_possible_truncation,
++    clippy::derive_partial_eq_without_eq,
++    clippy::doc_markdown,
++    clippy::enum_glob_use,
++    // https://github.com/rust-lang/rust-clippy/issues/8539
++    clippy::iter_with_drain,
++    clippy::module_name_repetitions,
++    clippy::must_use_candidate,
++    clippy::needless_doctest_main,
++    clippy::needless_pass_by_value,
++    clippy::redundant_else,
++    clippy::toplevel_ref_arg,
++    clippy::unreadable_literal
++)]
++
++extern crate proc_macro;
++
++mod attr;
++mod bound;
++mod constfn;
++mod date;
++mod error;
++mod expand;
++mod expr;
++mod iter;
++mod release;
++mod time;
++mod token;
++mod version;
++
++use crate::error::Error;
++use crate::version::Version;
++use proc_macro::TokenStream;
++
++#[cfg(not(host_os = "windows"))]
++const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.expr"));
++
++#[cfg(host_os = "windows")]
++const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "\\version.expr"));
++
++#[proc_macro_attribute]
++pub fn stable(args: TokenStream, input: TokenStream) -> TokenStream {
++    expand::cfg("stable", args, input)
++}
++
++#[proc_macro_attribute]
++pub fn beta(args: TokenStream, input: TokenStream) -> TokenStream {
++    expand::cfg("beta", args, input)
++}
++
++#[proc_macro_attribute]
++pub fn nightly(args: TokenStream, input: TokenStream) -> TokenStream {
++    expand::cfg("nightly", args, input)
++}
++
++#[proc_macro_attribute]
++pub fn since(args: TokenStream, input: TokenStream) -> TokenStream {
++    expand::cfg("since", args, input)
++}
++
++#[proc_macro_attribute]
++pub fn before(args: TokenStream, input: TokenStream) -> TokenStream {
++    expand::cfg("before", args, input)
++}
++
++#[proc_macro_attribute]
++pub fn not(args: TokenStream, input: TokenStream) -> TokenStream {
++    expand::cfg("not", args, input)
++}
++
++#[proc_macro_attribute]
++pub fn any(args: TokenStream, input: TokenStream) -> TokenStream {
++    expand::cfg("any", args, input)
++}
++
++#[proc_macro_attribute]
++pub fn all(args: TokenStream, input: TokenStream) -> TokenStream {
++    expand::cfg("all", args, input)
++}
++
++#[proc_macro_attribute]
++pub fn attr(args: TokenStream, input: TokenStream) -> TokenStream {
++    attr::parse(args)
++        .and_then(|args| expand::try_attr(args, input))
++        .unwrap_or_else(Error::into_compile_error)
++}
++
++#[cfg(not(cfg_macro_not_allowed))]
++#[proc_macro]
++pub fn cfg(input: TokenStream) -> TokenStream {
++    use proc_macro::{Ident, Span, TokenTree};
++    (|| {
++        let ref mut args = iter::new(input);
++        let expr = expr::parse(args)?;
++        token::parse_end(args)?;
++        let boolean = expr.eval(RUSTVERSION);
++        let ident = Ident::new(&boolean.to_string(), Span::call_site());
++        Ok(TokenStream::from(TokenTree::Ident(ident)))
++    })()
++    .unwrap_or_else(Error::into_compile_error)
++}
+diff --git a/third_party/rust/rustversion/src/release.rs b/third_party/rust/rustversion/src/release.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/release.rs
+@@ -0,0 +1,34 @@
++use crate::error::{Error, Result};
++use crate::iter::Iter;
++use crate::token;
++use proc_macro::Group;
++
++#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
++pub struct Release {
++    pub minor: u16,
++    pub patch: Option<u16>,
++}
++
++pub fn parse(paren: Group, iter: Iter) -> Result<Release> {
++    try_parse(iter).map_err(|()| Error::group(paren, "expected rustc release number, like 1.31"))
++}
++
++fn try_parse(iter: Iter) -> Result<Release, ()> {
++    let major_minor = token::parse_literal(iter).map_err(drop)?;
++    let string = major_minor.to_string();
++
++    if !string.starts_with("1.") {
++        return Err(());
++    }
++
++    let minor: u16 = string[2..].parse().map_err(drop)?;
++
++    let patch = if token::parse_optional_punct(iter, '.').is_some() {
++        let int = token::parse_literal(iter).map_err(drop)?;
++        Some(int.to_string().parse().map_err(drop)?)
++    } else {
++        None
++    };
++
++    Ok(Release { minor, patch })
++}
+diff --git a/third_party/rust/rustversion/src/time.rs b/third_party/rust/rustversion/src/time.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/time.rs
+@@ -0,0 +1,51 @@
++use crate::date::Date;
++use std::env;
++use std::time::{SystemTime, UNIX_EPOCH};
++
++// Timestamp of 2016-03-01 00:00:00 in UTC.
++const BASE: u64 = 1456790400;
++const BASE_YEAR: u16 = 2016;
++const BASE_MONTH: u8 = 3;
++
++// Days between leap days.
++const CYCLE: u64 = 365 * 4 + 1;
++
++const DAYS_BY_MONTH: [u8; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
++
++pub fn today() -> Date {
++    let default = Date {
++        year: 2025,
++        month: 2,
++        day: 25,
++    };
++    try_today().unwrap_or(default)
++}
++
++fn try_today() -> Option<Date> {
++    if let Some(pkg_name) = env::var_os("CARGO_PKG_NAME") {
++        if pkg_name.to_str() == Some("rustversion-tests") {
++            return None; // Stable date for ui testing.
++        }
++    }
++
++    let now = SystemTime::now();
++    let since_epoch = now.duration_since(UNIX_EPOCH).ok()?;
++    let secs = since_epoch.as_secs();
++
++    let approx_days = secs.checked_sub(BASE)? / 60 / 60 / 24;
++    let cycle = approx_days / CYCLE;
++    let mut rem = approx_days % CYCLE;
++
++    let mut year = BASE_YEAR + cycle as u16 * 4;
++    let mut month = BASE_MONTH;
++    loop {
++        let days_in_month = DAYS_BY_MONTH[month as usize - 1];
++        if rem < days_in_month as u64 {
++            let day = rem as u8 + 1;
++            return Some(Date { year, month, day });
++        }
++        rem -= days_in_month as u64;
++        year += (month == 12) as u16;
++        month = month % 12 + 1;
++    }
++}
+diff --git a/third_party/rust/rustversion/src/token.rs b/third_party/rust/rustversion/src/token.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/token.rs
+@@ -0,0 +1,78 @@
++use crate::error::{Error, Result};
++use crate::iter::Iter;
++use proc_macro::{Delimiter, Group, Ident, Literal, Span, TokenTree};
++
++pub fn parse_punct(iter: Iter, ch: char) -> Result<()> {
++    match iter.next() {
++        Some(TokenTree::Punct(ref punct)) if punct.as_char() == ch => Ok(()),
++        unexpected => {
++            let span = unexpected
++                .as_ref()
++                .map_or_else(Span::call_site, TokenTree::span);
++            Err(Error::new(span, format!("expected `{}`", ch)))
++        }
++    }
++}
++
++pub fn parse_optional_punct(iter: Iter, ch: char) -> Option<()> {
++    match iter.peek() {
++        Some(TokenTree::Punct(punct)) if punct.as_char() == ch => iter.next().map(drop),
++        _ => None,
++    }
++}
++
++pub fn parse_optional_keyword(iter: Iter, keyword: &str) -> Option<Span> {
++    match iter.peek() {
++        Some(TokenTree::Ident(ident)) if ident.to_string() == keyword => {
++            Some(iter.next().unwrap().span())
++        }
++        _ => None,
++    }
++}
++
++pub fn parse_literal(iter: Iter) -> Result<Literal> {
++    match iter.next() {
++        Some(TokenTree::Literal(literal)) => Ok(literal),
++        unexpected => {
++            let span = unexpected
++                .as_ref()
++                .map_or_else(Span::call_site, TokenTree::span);
++            Err(Error::new(span, "expected literal"))
++        }
++    }
++}
++
++pub fn parse_paren(introducer: &Ident, iter: Iter) -> Result<Group> {
++    match iter.peek() {
++        Some(TokenTree::Group(group)) if group.delimiter() == Delimiter::Parenthesis => {
++            match iter.next() {
++                Some(TokenTree::Group(group)) => Ok(group),
++                _ => unreachable!(),
++            }
++        }
++        Some(unexpected) => Err(Error::new(unexpected.span(), "expected `(`")),
++        None => Err(Error::new(
++            introducer.span(),
++            format!("expected `(` after `{}`", introducer),
++        )),
++    }
++}
++
++pub fn parse_optional_paren(iter: Iter) -> Option<Group> {
++    match iter.peek() {
++        Some(TokenTree::Group(group)) if group.delimiter() == Delimiter::Parenthesis => {
++            match iter.next() {
++                Some(TokenTree::Group(group)) => Some(group),
++                _ => unreachable!(),
++            }
++        }
++        _ => None,
++    }
++}
++
++pub fn parse_end(iter: Iter) -> Result<()> {
++    match iter.next() {
++        None => Ok(()),
++        Some(unexpected) => Err(Error::new(unexpected.span(), "unexpected token")),
++    }
++}
+diff --git a/third_party/rust/rustversion/src/version.rs b/third_party/rust/rustversion/src/version.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/src/version.rs
+@@ -0,0 +1,18 @@
++#![allow(dead_code)]
++
++use crate::date::Date;
++
++#[derive(Copy, Clone, Debug, PartialEq)]
++pub struct Version {
++    pub minor: u16,
++    pub patch: u16,
++    pub channel: Channel,
++}
++
++#[derive(Copy, Clone, Debug, PartialEq)]
++pub enum Channel {
++    Stable,
++    Beta,
++    Nightly(Date),
++    Dev,
++}
+diff --git a/third_party/rust/rustversion/tests/compiletest.rs b/third_party/rust/rustversion/tests/compiletest.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/compiletest.rs
+@@ -0,0 +1,7 @@
++#[rustversion::attr(not(nightly), ignore = "requires nightly")]
++#[cfg_attr(miri, ignore = "incompatible with miri")]
++#[test]
++fn ui() {
++    let t = trybuild::TestCases::new();
++    t.compile_fail("tests/ui/*.rs");
++}
+diff --git a/third_party/rust/rustversion/tests/test_const.rs b/third_party/rust/rustversion/tests/test_const.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/test_const.rs
+@@ -0,0 +1,42 @@
++#![allow(
++    clippy::semicolon_if_nothing_returned, // https://github.com/rust-lang/rust-clippy/issues/7324
++    clippy::used_underscore_items,
++)]
++
++#[rustversion::attr(all(), const)]
++fn _basic() {}
++const _BASIC: () = _basic();
++
++#[rustversion::attr(all(), const)]
++unsafe fn _unsafe() {}
++const _UNSAFE: () = unsafe { _unsafe() };
++
++macro_rules! item {
++    ($i:item) => {
++        #[rustversion::attr(all(), const)]
++        $i
++    };
++}
++
++item! {fn _item() {}}
++const _ITEM: () = _item();
++
++macro_rules! ident {
++    ($fn:ident) => {
++        #[rustversion::attr(all(), const)]
++        $fn _ident() {}
++    };
++}
++
++ident! {fn}
++const _IDENT: () = _ident();
++
++#[rustversion::attr(all(), const)]
++/// doc
++fn _doc_below() {}
++const _DOC_BELOW: () = _doc_below();
++
++/// doc
++#[rustversion::attr(all(), const)]
++fn _doc_above() {}
++const _DOC_ABOVE: () = _doc_above();
+diff --git a/third_party/rust/rustversion/tests/test_eval.rs b/third_party/rust/rustversion/tests/test_eval.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/test_eval.rs
+@@ -0,0 +1,20 @@
++#[rustversion::any(
++    stable,
++    stable(1.34),
++    stable(1.34.0),
++    beta,
++    nightly,
++    nightly(2020-02-25),
++    since(1.34),
++    since(2020-02-25),
++    before(1.34),
++    before(2020-02-25),
++    not(nightly),
++    all(stable, beta, nightly),
++)]
++fn success() {}
++
++#[test]
++fn test() {
++    success();
++}
+diff --git a/third_party/rust/rustversion/tests/test_parse.rs b/third_party/rust/rustversion/tests/test_parse.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/test_parse.rs
+@@ -0,0 +1,103 @@
++#![allow(
++    clippy::derive_partial_eq_without_eq,
++    clippy::enum_glob_use,
++    clippy::must_use_candidate
++)]
++
++include!("../build/rustc.rs");
++
++#[test]
++fn test_parse() {
++    let cases = &[
++        (
++            "rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14)",
++            Version {
++                minor: 0,
++                patch: 0,
++                channel: Stable,
++            },
++        ),
++        (
++            "rustc 1.18.0",
++            Version {
++                minor: 18,
++                patch: 0,
++                channel: Stable,
++            },
++        ),
++        (
++            "rustc 1.24.1 (d3ae9a9e0 2018-02-27)",
++            Version {
++                minor: 24,
++                patch: 1,
++                channel: Stable,
++            },
++        ),
++        (
++            "rustc 1.35.0-beta.3 (c13114dc8 2019-04-27)",
++            Version {
++                minor: 35,
++                patch: 0,
++                channel: Beta,
++            },
++        ),
++        (
++            "rustc 1.36.0-nightly (938d4ffe1 2019-04-27)",
++            Version {
++                minor: 36,
++                patch: 0,
++                channel: Nightly(Date {
++                    year: 2019,
++                    month: 4,
++                    day: 27,
++                }),
++            },
++        ),
++        (
++            "rustc 1.36.0-dev",
++            Version {
++                minor: 36,
++                patch: 0,
++                channel: Dev,
++            },
++        ),
++        (
++            "rustc 1.36.0-nightly",
++            Version {
++                minor: 36,
++                patch: 0,
++                channel: Dev,
++            },
++        ),
++        (
++            "warning: invalid logging spec 'warning', ignoring it
++             rustc 1.30.0-nightly (3bc2ca7e4 2018-09-20)",
++            Version {
++                minor: 30,
++                patch: 0,
++                channel: Nightly(Date {
++                    year: 2018,
++                    month: 9,
++                    day: 20,
++                }),
++            },
++        ),
++        (
++            "rustc 1.52.1-nightly (gentoo)",
++            Version {
++                minor: 52,
++                patch: 1,
++                channel: Dev,
++            },
++        ),
++    ];
++
++    for (string, expected) in cases {
++        match parse(string) {
++            ParseResult::Success(version) => assert_eq!(version, *expected),
++            ParseResult::OopsClippy | ParseResult::OopsMirai | ParseResult::Unrecognized => {
++                panic!("unrecognized: {:?}", string);
++            }
++        }
++    }
++}
+diff --git a/third_party/rust/rustversion/tests/ui/bad-bound.rs b/third_party/rust/rustversion/tests/ui/bad-bound.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/bad-bound.rs
+@@ -0,0 +1,7 @@
++#[rustversion::since(stable)]
++struct S;
++
++#[rustversion::any(since(stable))]
++struct S;
++
++fn main() {}
+diff --git a/third_party/rust/rustversion/tests/ui/bad-bound.stderr b/third_party/rust/rustversion/tests/ui/bad-bound.stderr
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/bad-bound.stderr
+@@ -0,0 +1,11 @@
++error: expected rustc release number like 1.85, or nightly date like 2025-02-25
++ --> tests/ui/bad-bound.rs:1:22
++  |
++1 | #[rustversion::since(stable)]
++  |                      ^^^^^^
++
++error: expected rustc release number like 1.85, or nightly date like 2025-02-25
++ --> tests/ui/bad-bound.rs:4:26
++  |
++4 | #[rustversion::any(since(stable))]
++  |                          ^^^^^^
+diff --git a/third_party/rust/rustversion/tests/ui/bad-date.rs b/third_party/rust/rustversion/tests/ui/bad-date.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/bad-date.rs
+@@ -0,0 +1,7 @@
++#[rustversion::nightly(stable)]
++struct S;
++
++#[rustversion::any(nightly(stable))]
++struct S;
++
++fn main() {}
+diff --git a/third_party/rust/rustversion/tests/ui/bad-date.stderr b/third_party/rust/rustversion/tests/ui/bad-date.stderr
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/bad-date.stderr
+@@ -0,0 +1,11 @@
++error: expected nightly date, like 2025-02-25
++ --> tests/ui/bad-date.rs:1:24
++  |
++1 | #[rustversion::nightly(stable)]
++  |                        ^^^^^^
++
++error: expected nightly date, like 2025-02-25
++ --> tests/ui/bad-date.rs:4:28
++  |
++4 | #[rustversion::any(nightly(stable))]
++  |                            ^^^^^^
+diff --git a/third_party/rust/rustversion/tests/ui/bad-not.rs b/third_party/rust/rustversion/tests/ui/bad-not.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/bad-not.rs
+@@ -0,0 +1,7 @@
++#[rustversion::any(not)]
++struct S;
++
++#[rustversion::any(not, not)]
++struct S;
++
++fn main() {}
+diff --git a/third_party/rust/rustversion/tests/ui/bad-not.stderr b/third_party/rust/rustversion/tests/ui/bad-not.stderr
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/bad-not.stderr
+@@ -0,0 +1,11 @@
++error: expected `(` after `not`
++ --> tests/ui/bad-not.rs:1:20
++  |
++1 | #[rustversion::any(not)]
++  |                    ^^^
++
++error: expected `(`
++ --> tests/ui/bad-not.rs:4:23
++  |
++4 | #[rustversion::any(not, not)]
++  |                       ^
+diff --git a/third_party/rust/rustversion/tests/ui/bad-version.rs b/third_party/rust/rustversion/tests/ui/bad-version.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/bad-version.rs
+@@ -0,0 +1,7 @@
++#[rustversion::stable(nightly)]
++struct S;
++
++#[rustversion::any(stable(nightly))]
++struct S;
++
++fn main() {}
+diff --git a/third_party/rust/rustversion/tests/ui/bad-version.stderr b/third_party/rust/rustversion/tests/ui/bad-version.stderr
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/bad-version.stderr
+@@ -0,0 +1,11 @@
++error: expected rustc release number, like 1.31
++ --> tests/ui/bad-version.rs:1:23
++  |
++1 | #[rustversion::stable(nightly)]
++  |                       ^^^^^^^
++
++error: expected rustc release number, like 1.31
++ --> tests/ui/bad-version.rs:4:27
++  |
++4 | #[rustversion::any(stable(nightly))]
++  |                           ^^^^^^^
+diff --git a/third_party/rust/rustversion/tests/ui/const-not-fn.rs b/third_party/rust/rustversion/tests/ui/const-not-fn.rs
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/const-not-fn.rs
+@@ -0,0 +1,4 @@
++#[rustversion::attr(all(), const)]
++pub struct S;
++
++fn main() {}
+diff --git a/third_party/rust/rustversion/tests/ui/const-not-fn.stderr b/third_party/rust/rustversion/tests/ui/const-not-fn.stderr
+new file mode 100644
+--- /dev/null
++++ b/third_party/rust/rustversion/tests/ui/const-not-fn.stderr
+@@ -0,0 +1,5 @@
++error: only allowed on a fn item
++ --> tests/ui/const-not-fn.rs:1:28
++  |
++1 | #[rustversion::attr(all(), const)]
++  |                            ^^^^^


### PR DESCRIPTION
this is the full patchset needed for seamonkey-2.53.24

it does not break backwards compability to rust lower than 1.95.0

source: https://bugzilla.mozilla.org/show_bug.cgi?id=1896958